### PR TITLE
docs: Tech stack change proposals to AutoMq and InFluxDB

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -75,21 +75,21 @@ The system is delivered in **modular increments**. Each increment produces a **f
 
 | Component | Deliverable |
 |-----------|------------|
-| **Docker Compose** | Dev stack: Kafka + Zookeeper, PostgreSQL + PostGIS, Redis |
-| **Database Schemas** | SQL scripts for all tables (routes, stops, buses, gps_readings, trips, etc.) |
+| **Docker Compose** | Dev stack: AutoMQ (or Kafka fallback), PostgreSQL + PostGIS, InfluxDB, Redis |
+| **Database Schemas** | SQL scripts for all PG tables, and initialization for InfluxDB buckets |
 | **Route Seeding** | Script to seed Moratuwa → Kadawatha route geometry + 20+ stops into PostGIS |
-| **GPS Simulator** | Python script that publishes fake GPS every 3–5 seconds to `transport-telemetry-raw` Kafka topic |
+| **GPS Simulator** | Python script that publishes fake GPS every 3–5 seconds to `transport-telemetry-raw` AutoMQ topic |
 | **CI Pipeline** | GitHub Actions: lint (ruff), type check (mypy), test (pytest), Docker build |
 | **FastAPI Skeleton** | `/health` and `/metrics` endpoints, Pydantic models for GPS + bus status schemas |
-| **Dev Config** | `.env.example` with local + Neon cloud DB URLs, Docker networking |
+| **Dev Config** | `.env.example` with local + Cloud DB URLs (Neon PG + InfluxDB Cloud), Docker networking |
 
 #### 5-Member Task Distribution
 
 | Member | Role | What They Own | Key Deliverables |
 |--------|------|--------------|-----------------|
-| **Janidu** | Infrastructure & Docker Lead | Docker environment | `docker/docker-compose.yml` (Kafka, Zookeeper, PG+PostGIS, Redis), `docker/.env.example`, health check wait scripts, Docker networking config |
-| **Kusal** | Database & Schema Lead | All database schemas | SQL migration scripts in `scripts/migrations/`, schema for all tables (routes, stops, buses, gps_readings, trips, stop_arrivals, anomalies, geofences), Neon cloud DB setup for team access, local PG+PostGIS config |
-| **Chamodh** | Data Seeding & Simulator Lead | Test data + GPS simulator | `scripts/seed_routes.py` (Moratuwa→Kadawatha route + 20+ stops with PostGIS LINESTRING/POINT geometry), `scripts/gps_simulator.py` (publishes fake GPS JSON every 3–5 seconds to Kafka `transport-telemetry-raw` topic) |
+| **Janidu** | Infrastructure & Docker Lead | Docker environment | `docker/docker-compose.yml` (Kafka/AutoMQ, PG+PostGIS, InfluxDB, Redis), `docker/.env.example`, health check wait scripts, Docker networking config |
+| **Kusal** | Database & Schema Lead | All database schemas | SQL migration scripts in `scripts/migrations/`, schema for all PG tables (routes, stops, buses, trips, stop_arrivals, anomalies, geofences) + InfluxDB telemetry schemas, Neon/InfluxDB cloud DB setup for team access, local config |
+| **Chamodh** | Data Seeding & Simulator Lead | Test data + GPS simulator | `scripts/seed_routes.py` (Moratuwa→Kadawatha route + 20+ stops with PostGIS LINESTRING/POINT geometry), `scripts/gps_simulator.py` (publishes fake GPS JSON every 3–5 seconds to AutoMQ `transport-telemetry-raw` topic) |
 | **Nidharshan** | CI/CD & Quality Lead | Pipeline + test framework | `.github/workflows/ci.yml` (ruff lint + mypy type check + pytest + Docker build), `tests/` directory structure with conftest.py, PR template, branch protection rules, `pyproject.toml` with tool configs |
 | **Nathasha** | Interface & Integration Lead | API skeleton + glue | `services/api-gateway/` FastAPI app with `/health` + `/metrics`, Pydantic models (`schemas/gps.py`, `schemas/bus_status.py`), project-wide folder structure, integration test that verifies: docker up → seed → simulate → health OK |
 
@@ -101,14 +101,14 @@ The system is delivered in **modular increments**. Each increment produces a **f
 Janidu (Docker)             Kusal (DB Schemas)
      │                          │
      │  docker compose up       │  SQL migration scripts
-     │  provides running        │  run against PG container
-     │  PG + Kafka + Redis      │  from Janidu
+     │  provides running        │  run against PG + Influx
+     │  PG + Influx + AutoMQ    │  containers from Janidu
      └──────────┬───────────────┘
                 │
      Chamodh (Seeding + Simulator)
                 │
      seed_routes.py writes to PG (Kusal's schema)
-     gps_simulator.py publishes to Kafka (Janidu's container)
+     gps_simulator.py publishes to AutoMQ (Janidu's container)
                 │
      Nidharshan (CI/CD)
                 │
@@ -126,16 +126,16 @@ The project uses **two database options** via a single `.env.example`:
 
 | Option | When to Use | Setup |
 |--------|-------------|-------|
-| **Local PostgreSQL** (Docker) | Solo development, testing, CI | Automatically starts via `docker compose up`. Connection: `postgresql://ontime:ontime@localhost:5432/ontime` |
-| **Neon Cloud PostgreSQL** | Team collaboration, shared data | Team lead creates Neon project, shares connection URL privately. Connection: `postgresql://user:pass@ep-xxx.neon.tech/ontime?sslmode=require` |
+| **Local DBs (Docker)** | Solo development, testing, CI | Automatically starts via `docker compose up`. Connections: PG (`localhost:5432`), InfluxDB (`localhost:8086`) |
+| **Team Cloud DBs** | Team collaboration, shared data | Team lead creates Neon PG + InfluxDB Cloud projects, shares connection URLs privately.  |
 
 Members set the active `DATABASE_URL` in their local `.env` file (never committed to git).
 
 #### Acceptance Criteria
 
-- [ ] `docker compose up` brings up Kafka + PostgreSQL + Redis with zero errors
+- [ ] `docker compose up` brings up AutoMQ/Kafka + PostgreSQL + InfluxDB + Redis with zero errors
 - [ ] `python scripts/seed_routes.py` populates route + 20 stops in PostGIS
-- [ ] `python scripts/gps_simulator.py` publishes GPS messages to `transport-telemetry-raw` Kafka topic
+- [ ] `python scripts/gps_simulator.py` publishes GPS messages to `transport-telemetry-raw` AutoMQ topic
 - [ ] `curl localhost:8000/health` returns 200 with dependency statuses
 - [ ] GitHub Actions runs lint + type check + tests on every push and passes
 
@@ -155,7 +155,7 @@ Members set the active `DATABASE_URL` in their local `.env` file (never committe
 
 | Component | Deliverable |
 |-----------|------------|
-| **Ingestion Service** | MQTT → Kafka bridge; Pydantic validation; DLQ routing for invalid GPS |
+| **Ingestion Service** | MQTT → AutoMQ bridge; Pydantic validation; DLQ routing for invalid GPS. *Note: G1 calculates speed and heading locally on the node.* |
 | **Stream Processing** | Flink job: Kalman filter + bounding box check (no feature extraction yet) |
 | **Bus State Machine** | `WAITING_AT_DEPOT → DEPARTED_ORIGIN → EN_ROUTE → ARRIVED_DESTINATION` (↕ `INCIDENT_REPORTED` from `EN_ROUTE`, admin reset: `ARRIVED_DESTINATION → WAITING_AT_DEPOT`) |
 | **Driver Status API** | `POST /api/v1/trips/{id}/state` - driver taps to change trip state; `POST /api/v1/driver/start-trip` - driver starts trip |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ OnTime's first release focuses on two core user roles:
 ## 🏗️ System Architecture
 
 ```
-┌─────────────┐     MQTT      ┌──────────────┐    Kafka     ┌──────────────────┐
+┌─────────────┐     MQTT      ┌──────────────┐   AutoMQ   ┌──────────────────┐
 │  G1 — Edge  │──────────────▶│  G2 — Data   │────────────▶│  G2 — Stream     │
 │  (GPS/IoT)  │               │  Ingestion    │             │  Processing      │
 └─────────────┘               └──────────────┘             └────────┬─────────┘
@@ -57,7 +57,7 @@ OnTime's first release focuses on two core user roles:
                     │                    │                            │
               ┌─────▼──────┐    ┌───────▼────────┐    ┌─────────────▼───────┐
               │ ETA Model  │    │ Anomaly Detect │    │  PostgreSQL/PostGIS │
-              │ (XGBoost)  │    │ (3-Layer)      │    │  + Redis Cache      │
+              │ (XGBoost)  │    │ (3-Layer)      │    │  & InfluxDB + Redis │
               └─────┬──────┘    └───────┬────────┘    └─────────┬───────────┘
                     │                    │                        │
               ┌─────▼────────────────────▼────────────────────────▼───┐
@@ -97,8 +97,8 @@ OnTime's first release focuses on two core user roles:
 |----------|-----------|-----------|
 | **Language** | Python 3.12 | All increments |
 | **API Framework** | FastAPI | Inc 0+ |
-| **Message Broker** | Apache Kafka (Confluent 7.6) | Inc 0+ |
-| **Database** | PostgreSQL 16 + PostGIS 3.4 | Inc 0+ |
+| **Message Broker** | AutoMQ (Kafka-compatible, S3-backed) | Inc 0+ |
+| **Databases** | PostgreSQL 16 (Relational/Spatial) + InfluxDB (Time-Series) | Inc 0+ |
 | **Cache** | Redis | Inc 0+ |
 | **Stream Processing** | Apache Flink (PyFlink) | Inc 1+ |
 | **ML Framework** | XGBoost, scikit-learn | Inc 2+ |
@@ -156,9 +156,10 @@ cd ontime-g2
 
 # 2. Copy environment config
 cp .env.example .env
-# Edit .env — uncomment the DATABASE_URL you want (local or Neon cloud)
+# Edit .env — uncomment the connections you want (local Docker URLs or Cloud connections like Neon PG / InfluxDB Cloud)
 
-# 3. Start infrastructure (Kafka, PostgreSQL, Redis)
+# 3. Start infrastructure locally
+# Note: Production uses AutoMQ (cloud-native Kafka), but local dev spins up standard Kafka/Zookeeper, PostgreSQL, InfluxDB, and Redis.
 docker compose -f docker/docker-compose.yml up -d
 
 # 4. Install Python dependencies

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -75,7 +75,7 @@ G2 is decomposed into independently deployable services. Services marked **(futu
 
 ### 2.2 Service Catalog
 
-| Service | Port | Kafka Consumes | Kafka Produces | Increment |
+| Service | Port | AutoMQ Consumes | AutoMQ Produces | Increment |
 |---------|------|----------------|----------------|-----------|
 | **API Gateway** | 8000 | `transport-anomaly-alerts` | — | 0 (skeleton) |
 | **Ingestion Service** | 8001 | — | `transport-telemetry-raw`, `transport-telemetry-dlq` | 1 |
@@ -155,7 +155,9 @@ G2 communicates through separate logical ports for independent data flows.
 
 ## 3. Event-Driven Architecture
 
-### 3.1 Kafka Topic Design
+### 3.1 AutoMQ Topic Design
+
+> **Note:** AutoMQ brokers are **stateless**. This means topic partitions are stored directly in cloud object storage (like AWS S3) rather than on physical broker disks, guaranteeing rapid 10-second scaling without the "partition tax" of traditional standard Kafka.
 
 ```
 # Active in first release
@@ -199,12 +201,12 @@ Stream Processing (Flink — Inc 1)
 
 ### 4.1 Database Strategy
 
-**PostgreSQL 16 + PostGIS 3.4** is the primary data store. Services share a single PostgreSQL instance for the MVP (schema isolation for logical separation).
+The primary data store is split into two specialized databases to maximize performance and elasticity:
+
+**1. PostgreSQL 16 + PostGIS 3.4 (Static/Relational)**
+Used for core business logic, users, and geographic routes. Services share a single PostgreSQL instance for the MVP (schema isolation).
 
 ```
-Schema: ingestion
-  └── gps_readings (partitioned by date)
-
 Schema: routes
   ├── routes (LINESTRING geometry)
   ├── stops (POINT geometry)
@@ -224,7 +226,16 @@ Schema: scheduling                 ← Inc 3 (future)
   └── bus_availability
 ```
 
-> **All schemas are created in Increment 0** via migration scripts, even for future services. This ensures the database structure is ready and documented upfront.
+**2. InfluxDB (Time-Series / Telemetry)**
+Used strictly for high-throughput stream storage and historical aggregation.
+
+```
+Bucket: telemetry
+  ├── gps_readings (bus_id, lat, lng, speed, heading, timestamp)
+  └── eta_predictions (bus_id, stop_id, eta)
+```
+
+> **All schemas and buckets are created in Increment 0** via migration and init scripts, even for future services. This ensures the database structure is ready and documented upfront.
 
 ### 4.2 Caching Strategy (Redis)
 
@@ -400,9 +411,10 @@ Push to any branch → Lint (ruff) → Type Check (mypy) → Unit Tests (pytest)
 | ML Framework for ETA | XGBoost | Tabular data, fast inference, interpretable | LSTM (overkill), LightGBM (similar) |
 | Stream Processing | Apache Flink (PyFlink) | True stream processing, watermarks, exactly-once | Spark Streaming (micro-batch), Kafka Streams |
 | API Framework | FastAPI | Async, type-safe, auto-docs, Python native | Flask (no async), Django (too heavy) |
-| Database | PostgreSQL + PostGIS | Spatial queries, mature, free | MongoDB (no spatial), InfluxDB (no relational) |
+| Database | PostgreSQL + PostGIS | Spatial queries, mature, free | MongoDB (no spatial) |
+| Telemetry Database | InfluxDB | Time-series optimized, handles massive write throughput from streams | PostgreSQL Partitioning (overhead, scale issues) |
 | Cache | Redis | Sub-ms latency, pub/sub capability | Memcached (no pub/sub) |
-| Message Broker | Apache Kafka | Event sourcing, replay, partitioning | RabbitMQ (no replay), Redis Streams (less durable) |
+| Message Broker | AutoMQ (Kafka-compatible) | Stateless, S3-backed storage, extremely elastic cloud scaling | Apache Kafka (Disk-bound), RabbitMQ |
 | Anomaly Detection | 3-Layer hybrid | Statistical + ML + Rules covers all edge cases | Single ML model, pure rules |
 | Auth Provider | Keycloak (G4) | Centralized, RBAC, OIDC compliant | Custom auth, Firebase (vendor lock) |
 


### PR DESCRIPTION
I have proposed Several architectural + tech stack changes :
1. Hybrid database method Postgre SQL + PostGIS fro master (static) data and InFluxDB for time based data to store recent bus speeds and ETAs.
2. Transitioning from Apache kafka to AutoMQ(100% kafka compatible).
- But Note that kafka can be still used in local dev and testing but when it comes to cloud hosting stage AutoMQ offers several benefits.
- AutoMQ is staeless,diskless and serverless event logger. Unlike traditional disk based Kafka, Auomq uses AWS S3 storage. So it does not have physical drives attached. scaling is easy and fast. additionally this makes system robust as quick recovery when Automq server crashes.