### PR TITLE
feat : docker-compose.yaml and enhanced .env.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# IDEs
+.idea/
+.vscode/
+
+# Database / OS
+*.sqlite3
+.DS_Store
+
+# Test / Coverage
+htmlcov/
+.coverage
+.coverage.*
+.pytest_cache/

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,21 +1,51 @@
-# Postgres Core Database
+# ==========================================
+# POSTGRESQL (Core Database)
+# ==========================================
+# Local Docker Setup
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=your_secure_password
 POSTGRES_DB=ontime_db
 POSTGRES_PORT=5432
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:${POSTGRES_PORT}/${POSTGRES_DB}
 
-# InfluxDB Time-Series Telemetry (Init Setup)
+# Cloud Setup (Neon.tech) - Uncomment to use Cloud
+# DATABASE_URL=postgresql://<user>:<password>@<neon_hostname>/<dbname>?sslmode=require
+
+# ==========================================
+# INFLUXDB (Time-Series Telemetry)
+# ==========================================
+# Local Docker Setup
 INFLUXDB_INIT_MODE=setup
 INFLUXDB_INIT_USERNAME=admin
 INFLUXDB_INIT_PASSWORD=adminpassword
 INFLUXDB_INIT_ORG=ontime
 INFLUXDB_INIT_BUCKET=telemetry
 INFLUXDB_ADMIN_TOKEN=your_super_secret_auth_token
-INFLUXDB_PORT=8086
+INFLUXDB_URL=http://influxdb:8086
 
-# Redis Live Cache
-REDIS_PORT=6379
+# Cloud Setup (InfluxDB Cloud) - Uncomment to use Cloud
+# INFLUXDB_URL=https://us-east-1-1.aws.cloud2.influxdata.com
+# INFLUXDB_ADMIN_TOKEN=your_cloud_all_access_token
+# INFLUXDB_INIT_ORG=your_cloud_org_name
+# INFLUXDB_INIT_BUCKET=telemetry
 
-# Kafka Broker Configuration (Local KRaft or Cloud AutoMQ)
+# ==========================================
+# REDIS (Live Cache & WebSockets)
+# ==========================================
+# Local Docker Setup
+REDIS_URL=redis://redis:6379
+
+# Cloud Setup (Upstash Redis) - Uncomment to use Cloud
+# REDIS_URL=rediss://default:<password>@<upstash_hostname>:<port>
+
+# ==========================================
+# KAFKA / AUTOMQ (Message Broker)
+# ==========================================
+# Local Docker Setup (KRaft)
 KAFKA_BROKER_URL=broker:29092
-# KAFKA_BROKER_URL=YOUR_CLOUD_AUTOMQ_URL_HERE
+
+# Cloud Setup (Upstash Kafka / Confluent / AutoMQ) - Uncomment to use Cloud
+# KAFKA_BROKER_URL=<your_cloud_broker_url>:9092
+# KAFKA_SASL_USERNAME=<your_cluster_username>
+# KAFKA_SASL_PASSWORD=<your_cluster_password>
+# KAFKA_SASL_MECHANISM=SCRAM-SHA-256 # Or PLAIN depending on provider

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,21 @@
+# Postgres Core Database
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=your_secure_password
+POSTGRES_DB=ontime_db
+POSTGRES_PORT=5432
+
+# InfluxDB Time-Series Telemetry (Init Setup)
+INFLUXDB_INIT_MODE=setup
+INFLUXDB_INIT_USERNAME=admin
+INFLUXDB_INIT_PASSWORD=adminpassword
+INFLUXDB_INIT_ORG=ontime
+INFLUXDB_INIT_BUCKET=telemetry
+INFLUXDB_ADMIN_TOKEN=your_super_secret_auth_token
+INFLUXDB_PORT=8086
+
+# Redis Live Cache
+REDIS_PORT=6379
+
+# Kafka Broker Configuration (Local KRaft or Cloud AutoMQ)
+KAFKA_BROKER_URL=broker:29092
+# KAFKA_BROKER_URL=YOUR_CLOUD_AUTOMQ_URL_HERE

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,79 @@
+services:
+  postgres:
+    image: postgis/postgis:16-3.4
+    container_name: ontime_postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-ontime_db}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - ontime_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-ontime_db}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: ontime_redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    networks:
+      - ontime_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  influxdb:
+    image: influxdb:2
+    container_name: ontime_influxdb
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: ${INFLUXDB_INIT_MODE:-setup}
+      DOCKER_INFLUXDB_INIT_USERNAME: ${INFLUXDB_INIT_USERNAME:-admin}
+      DOCKER_INFLUXDB_INIT_PASSWORD: ${INFLUXDB_INIT_PASSWORD:-adminpassword}
+      DOCKER_INFLUXDB_INIT_ORG: ${INFLUXDB_INIT_ORG:-ontime}
+      DOCKER_INFLUXDB_INIT_BUCKET: ${INFLUXDB_INIT_BUCKET:-telemetry}
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${INFLUXDB_ADMIN_TOKEN:-super_secret_admin_token_123}
+    ports:
+      - "${INFLUXDB_PORT:-8086}:8086"
+    volumes:
+      - influxdb_data:/var/lib/influxdb2
+      - influxdb_config:/etc/influxdb2
+    networks:
+      - ontime_network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8086/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  broker:
+    image: confluentinc/confluent-local:7.5.0
+    container_name: ontime_kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+    networks:
+      - ontime_network
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics --bootstrap-server localhost:9092 --list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+networks:
+  ontime_network:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  influxdb_data:
+  influxdb_config:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,6 +18,20 @@ services:
       timeout: 5s
       retries: 5
 
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: ontime_pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "admin@ontime.lk"
+      PGADMIN_DEFAULT_PASSWORD: "admin"
+    ports:
+      - "5050:80"
+    networks:
+      - ontime_network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   redis:
     image: redis:7-alpine
     container_name: ontime_redis


### PR DESCRIPTION
I changed .env.example and added docker-compose.yaml file. Now the Postgres + Redis + inFlux + kafka (for local dev) services run correctly as docker containers.

Cloud URL s are commented in .env.example can be later changed with Group 4 collaboration. For local dev and testing use .env as exactly in .env.example.

I will close Previous PR as this is enhancement to it.