### PR TITLE
refactor: Migrate GPS simulator from Kafka to MQTT and enforce strict GPSMessage schema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ iniconfig==2.3.0
 kafka-python==2.3.1
 numpy==2.4.4
 packaging==26.1
+paho-mqtt==2.1.0
 pluggy==1.6.0
 psycopg2-binary==2.9.12
 pydantic==2.13.3

--- a/scripts/gps_simulator.py
+++ b/scripts/gps_simulator.py
@@ -1,4 +1,6 @@
 # scripts/gps_simulator.py
+# GPS Simulator - publishes simulated bus GPS telemetry via MQTT.
+# The Ingestion Service subscribes to MQTT and bridges validated messages to Kafka.
 
 import json
 import math
@@ -7,7 +9,7 @@ import signal
 import time
 from typing import List, Tuple
 
-from kafka import KafkaProducer
+import paho.mqtt.client as mqtt
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from geoalchemy2.shape import to_shape
@@ -33,11 +35,30 @@ def get_engine():
     return create_engine(settings.database_url, echo=False)
 
 
-def get_producer() -> KafkaProducer:
-    return KafkaProducer(
-        bootstrap_servers=settings.kafka_bootstrap_servers,
-        value_serializer=lambda value: json.dumps(value).encode("utf-8"),
+def get_mqtt_client() -> mqtt.Client:
+    client = mqtt.Client(
+        client_id=f"gps-simulator-{settings.bus_id}",
+        protocol=mqtt.MQTTv311,
     )
+
+    def on_connect(client, userdata, flags, rc):
+        if rc == 0:
+            print(f"Connected to MQTT broker at {settings.mqtt_broker_host}:{settings.mqtt_broker_port}")
+        else:
+            print(f"MQTT connection failed with code {rc}")
+
+    def on_disconnect(client, userdata, rc):
+        if rc != 0:
+            print(f"Unexpected MQTT disconnect (code {rc}). Will auto-reconnect.")
+
+    client.on_connect = on_connect
+    client.on_disconnect = on_disconnect
+    client.connect(
+        settings.mqtt_broker_host,
+        settings.mqtt_broker_port,
+    )
+    client.loop_start()
+    return client
 
 
 def load_route_points() -> List[Tuple[float, float]]:
@@ -86,6 +107,27 @@ def haversine_km(
     return earth_radius_km * c
 
 
+def calculate_bearing(
+    lon1: float,
+    lat1: float,
+    lon2: float,
+    lat2: float
+) -> float:
+    """Calculate bearing (heading) in degrees between two GPS points."""
+    lat1_r = math.radians(lat1)
+    lat2_r = math.radians(lat2)
+    dlon_r = math.radians(lon2 - lon1)
+
+    x = math.sin(dlon_r) * math.cos(lat2_r)
+    y = (
+        math.cos(lat1_r) * math.sin(lat2_r)
+        - math.sin(lat1_r) * math.cos(lat2_r) * math.cos(dlon_r)
+    )
+
+    bearing = math.degrees(math.atan2(x, y))
+    return round(bearing % 360, 1)
+
+
 def create_message(
     prev_lon: float,
     prev_lat: float,
@@ -106,21 +148,20 @@ def create_message(
             distance_km / seconds_elapsed
         ) * 3600
 
-    crowd_status = random.choice(
-        [
-            "NOT_FULL",
-            "SEMI_FULL",
-            "FULL",
-        ]
+    heading = calculate_bearing(
+        prev_lon,
+        prev_lat,
+        lon,
+        lat
     )
 
     return {
         "busId": settings.bus_id,
-        "routeId": settings.route_name,
+        "tripId": settings.trip_id,
         "lat": round(lat, 6),
-        "lng": round(lon, 6),
+        "lon": round(lon, 6),
         "speed": round(speed_kmh, 1),
-        "crowdStatus": crowd_status,
+        "heading": heading,
         "timestamp": time.strftime(
             "%Y-%m-%dT%H:%M:%SZ",
             time.gmtime()
@@ -129,11 +170,12 @@ def create_message(
 
 
 def publish_loop():
-    producer = get_producer()
+    client = get_mqtt_client()
     route_points = load_route_points()
+    mqtt_topic = f"transport/bus/{settings.bus_id}/location"
 
-    print("GPS simulator started 🚍")
-    print(f"Topic: {settings.telemetry_topic}")
+    print("GPS simulator started (MQTT mode) 🚍")
+    print(f"MQTT topic: {mqtt_topic}")
     print(f"Loaded {len(route_points)} route points")
 
     index = 1
@@ -155,18 +197,18 @@ def publish_loop():
             wait_seconds
         )
 
-        producer.send(
-            settings.telemetry_topic,
-            payload
+        result = client.publish(
+            mqtt_topic,
+            json.dumps(payload),
         )
-        producer.flush()
+        result.wait_for_publish()
 
         print(
             f"Published: {payload['busId']} "
             f"lat={payload['lat']} "
-            f"lng={payload['lng']} "
+            f"lon={payload['lon']} "
             f"speed={payload['speed']} km/h "
-            f"crowd={payload['crowdStatus']}"
+            f"heading={payload['heading']}°"
         )
 
         time.sleep(wait_seconds)
@@ -176,7 +218,8 @@ def publish_loop():
         if index >= len(route_points):
             index = 1
 
-    producer.close()
+    client.loop_stop()
+    client.disconnect()
     print("GPS simulator stopped.")
 
 

--- a/scripts/models/settings.py
+++ b/scripts/models/settings.py
@@ -19,9 +19,9 @@ class Settings(BaseSettings):
     # Route Seeding
     route_name: str = Field(default="Moratuwa to Kadawatha", validation_alias="ROUTE_NAME")
 
-    # Kafka / AutoMQ / Redpanda
-    kafka_bootstrap_servers: str = Field(default="broker:29092", validation_alias="KAFKA_BROKER_URL")
-    telemetry_topic: str = Field(default="transport-telemetry-raw", validation_alias="TELEMETRY_TOPIC")
+    # MQTT Broker
+    mqtt_broker_host: str = Field(default="mqtt-broker", validation_alias="MQTT_BROKER_HOST")
+    mqtt_broker_port: int = Field(default=1883, validation_alias="MQTT_BROKER_PORT")
 
     # GPS Simulator
     bus_id: str = Field(default="BUS_001", validation_alias="BUS_ID")

--- a/tests/unit/test_gps_simulator.py
+++ b/tests/unit/test_gps_simulator.py
@@ -1,7 +1,8 @@
 # tests/unit/test_gps_simulator.py
 
+import json
 import scripts.gps_simulator as gps_simulator
-from scripts.gps_simulator import create_message, haversine_km
+from scripts.gps_simulator import create_message, haversine_km, calculate_bearing
 
 
 def test_haversine_zero_distance():
@@ -22,6 +23,20 @@ def test_haversine_positive_distance():
     assert distance > 0
 
 
+def test_calculate_bearing():
+    bearing = calculate_bearing(
+        79.8612, 6.9271,
+        79.8612, 6.9371  # Moving straight North
+    )
+    assert bearing == 0.0
+
+    bearing_east = calculate_bearing(
+        79.8612, 6.9271,
+        79.8712, 6.9271  # Moving straight East
+    )
+    assert bearing_east == 90.0
+
+
 def test_create_message_has_required_fields():
     payload = create_message(
         79.8612, 6.9271,
@@ -31,11 +46,11 @@ def test_create_message_has_required_fields():
 
     expected_keys = {
         "busId",
-        "routeId",
+        "tripId",
         "lat",
-        "lng",
+        "lon",
         "speed",
-        "crowdStatus",
+        "heading",
         "timestamp",
     }
 
@@ -50,7 +65,7 @@ def test_create_message_coordinates_precision():
     )
 
     assert payload["lat"] == round(payload["lat"], 6)
-    assert payload["lng"] == round(payload["lng"], 6)
+    assert payload["lon"] == round(payload["lon"], 6)
 
 
 def test_create_message_speed_non_negative():
@@ -61,20 +76,6 @@ def test_create_message_speed_non_negative():
     )
 
     assert payload["speed"] >= 0
-
-
-def test_create_message_valid_crowd_status():
-    payload = create_message(
-        79.8612, 6.9271,
-        79.8712, 6.9371,
-        4
-    )
-
-    assert payload["crowdStatus"] in {
-        "NOT_FULL",
-        "SEMI_FULL",
-        "FULL",
-    }
 
 
 def test_create_message_timestamp_format():
@@ -90,26 +91,30 @@ def test_create_message_timestamp_format():
 
 def test_publish_loop_sends_telemetry_to_configured_topic(monkeypatch):
     sent_messages = []
-    flush_called = False
-    close_called = False
+    loop_stopped = False
+    disconnected = False
 
-    class FakeProducer:
-        def send(self, topic, payload):
+    class FakeMQTTClient:
+        def publish(self, topic, payload):
             sent_messages.append((topic, payload))
+            class FakeResult:
+                def wait_for_publish(self):
+                    pass
+            return FakeResult()
 
-        def flush(self):
-            nonlocal flush_called
-            flush_called = True
+        def loop_stop(self):
+            nonlocal loop_stopped
+            loop_stopped = True
 
-        def close(self):
-            nonlocal close_called
-            close_called = True
+        def disconnect(self):
+            nonlocal disconnected
+            disconnected = True
 
     def fake_sleep(_seconds):
         gps_simulator.running = False
 
     monkeypatch.setattr(gps_simulator, "running", True)
-    monkeypatch.setattr(gps_simulator, "get_producer", lambda: FakeProducer())
+    monkeypatch.setattr(gps_simulator, "get_mqtt_client", lambda: FakeMQTTClient())
     monkeypatch.setattr(
         gps_simulator,
         "load_route_points",
@@ -120,14 +125,16 @@ def test_publish_loop_sends_telemetry_to_configured_topic(monkeypatch):
     )
     monkeypatch.setattr(gps_simulator.random, "randint", lambda _min, _max: 4)
     monkeypatch.setattr(gps_simulator.time, "sleep", fake_sleep)
-    monkeypatch.setattr(gps_simulator.settings, "telemetry_topic", "transport-telemetry-raw")
 
     gps_simulator.publish_loop()
 
     assert len(sent_messages) == 1
-    topic, payload = sent_messages[0]
-    assert topic == gps_simulator.settings.telemetry_topic
-    assert payload["routeId"] == gps_simulator.settings.route_name
+    topic, payload_str = sent_messages[0]
+    expected_topic = f"transport/bus/{gps_simulator.settings.bus_id}/location"
+    assert topic == expected_topic
+    
+    payload = json.loads(payload_str)
+    assert payload["tripId"] == gps_simulator.settings.trip_id
     assert payload["busId"] == gps_simulator.settings.bus_id
-    assert flush_called is True
-    assert close_called is True
+    assert loop_stopped is True
+    assert disconnected is True


### PR DESCRIPTION
Migrates the GPS simulator from publishing directly to Kafka to publishing via **MQTT**. All GPS telemetry now flows through the MQTT broker (added in PR #1), ensuring the Ingestion Service is the single validated gateway to Kafka.
Also enforces the shared `GPSMessage` Pydantic schema — no extra fields, no missing fields.
### Changes Summary
| File | What Changed |
|------|-------------|
| `scripts/gps_simulator.py` | `KafkaProducer` → `paho.mqtt.client`, publishes to `transport/bus/{busId}/location` |
| `scripts/models/settings.py` | Kafka settings → MQTT settings (`mqtt_broker_host`, `mqtt_broker_port`) |
| `requirements.txt` | Added `paho-mqtt==2.1.0` |
### Schema Fixes
| Field | Before | After |
|-------|--------|-------|
| `lng` | ❌ Used | ✅ Fixed to `lon` (matches `GPSMessage`) |
| `tripId` | ❌ Missing | ✅ Added (required by `GPSMessage`) |
| `heading` | ❌ Missing | ✅ Added with bearing calculation |
| `crowdStatus` | ❌ Sent | ✅ Removed (not in `GPSMessage`) |
| `routeId` | ❌ Sent | ✅ Removed (not in `GPSMessage`) |
### How to Test
```bash
# Start the MQTT broker (from PR #1)
cd docker && docker compose up -d mqtt-broker
# Subscribe to see messages (terminal 1)
mosquitto_sub -h localhost -p 1883 -t "transport/bus/#" -v
# Run the simulator (terminal 2 - needs DB with seeded route)
python -m scripts.gps_simulator
```