### PR TITLE
fix: enforce GPSMessage schema constraints on simulator

### DIFF
--- a/scripts/gps_simulator.py
+++ b/scripts/gps_simulator.py
@@ -80,6 +80,27 @@ def haversine_km(
     return earth_radius_km * c
 
 
+def calculate_bearing(
+    lon1: float,
+    lat1: float,
+    lon2: float,
+    lat2: float
+) -> float:
+    """Calculate bearing (heading) in degrees between two GPS points."""
+    lat1_r = math.radians(lat1)
+    lat2_r = math.radians(lat2)
+    dlon_r = math.radians(lon2 - lon1)
+
+    x = math.sin(dlon_r) * math.cos(lat2_r)
+    y = (
+        math.cos(lat1_r) * math.sin(lat2_r)
+        - math.sin(lat1_r) * math.cos(lat2_r) * math.cos(dlon_r)
+    )
+
+    bearing = math.degrees(math.atan2(x, y))
+    return round(bearing % 360, 1)
+
+
 def create_status_message(
     bus_id: int,
     route_id: int,
@@ -102,16 +123,15 @@ def create_location_message(
     lon: float,
     lat: float
 ) -> dict:
+    heading = calculate_bearing(prev_lon, prev_lat, lon, lat)
+    
     return {
-        "type": "LOCATION",
-        "busId": bus_id,
-        "routeId": route_id,
+        "busId": str(bus_id),
+        "tripId": f"TRIP_{bus_id}",
         "lat": round(lat, 6),
-        "lng": round(lon, 6),
+        "lon": round(lon, 6),
         "speed": random.randint(30, 50),
-        "crowdStatus": random.choice(
-            ["NOT_FULL", "SEMI_FULL", "FULL"]
-        ),
+        "heading": heading,
         "timestamp": now_utc(),
     }
 
@@ -222,9 +242,9 @@ def publish_loop():
             "index": 0,
         }
 
-        topic = (
+        topic_status = (
             f"transport/bus/"
-            f"{bus.id}/location"
+            f"{bus.id}/status"
         )
 
         start_payload = create_status_message(
@@ -235,7 +255,7 @@ def publish_loop():
 
         publish_json(
             client,
-            topic,
+            topic_status,
             start_payload
         )
 
@@ -257,9 +277,9 @@ def publish_loop():
             points = route_points[route.id]
 
             if index >= len(points) - 1:
-                topic = (
+                topic_status = (
                     f"transport/bus/"
-                    f"{bus.id}/location"
+                    f"{bus.id}/status"
                 )
 
                 stop_payload = create_status_message(
@@ -270,7 +290,7 @@ def publish_loop():
 
                 publish_json(
                     client,
-                    topic,
+                    topic_status,
                     stop_payload
                 )
 
@@ -293,9 +313,9 @@ def publish_loop():
                     "index": 0,
                 }
 
-                next_topic = (
+                next_topic_status = (
                     f"transport/bus/"
-                    f"{next_bus.id}/location"
+                    f"{next_bus.id}/status"
                 )
 
                 start_payload = create_status_message(
@@ -306,7 +326,7 @@ def publish_loop():
 
                 publish_json(
                     client,
-                    next_topic,
+                    next_topic_status,
                     start_payload
                 )
 
@@ -349,7 +369,8 @@ def publish_loop():
                 f"LOCATION bus={bus.id} "
                 f"route={route.id} "
                 f"lat={payload['lat']} "
-                f"lng={payload['lng']}"
+                f"lon={payload['lon']} "
+                f"heading={payload['heading']}°"
             )
 
             state["index"] = index + 1

--- a/tests/unit/test_gps_simulator.py
+++ b/tests/unit/test_gps_simulator.py
@@ -12,6 +12,7 @@ from scripts.gps_simulator import (
     create_status_message,
     haversine_km,
     publish_json,
+    calculate_bearing,
 )
 
 
@@ -63,11 +64,6 @@ def test_create_location_message_has_required_fields(monkeypatch):
     )
     monkeypatch.setattr(
         gps_simulator.random,
-        "choice",
-        lambda values: values[0]
-    )
-    monkeypatch.setattr(
-        gps_simulator.random,
         "randint",
         lambda _min, _max: 40
     )
@@ -82,22 +78,19 @@ def test_create_location_message_has_required_fields(monkeypatch):
     )
 
     expected_keys = {
-        "type",
         "busId",
-        "routeId",
+        "tripId",
         "lat",
-        "lng",
+        "lon",
         "speed",
-        "crowdStatus",
+        "heading",
         "timestamp",
     }
 
     assert set(payload.keys()) == expected_keys
-    assert payload["type"] == "LOCATION"
-    assert payload["busId"] == 10
-    assert payload["routeId"] == 20
+    assert payload["busId"] == "10"
+    assert payload["tripId"] == "TRIP_10"
     assert payload["speed"] == 40
-    assert payload["crowdStatus"] == "NOT_FULL"
     assert payload["timestamp"] == "2026-04-27T12:00:00Z"
 
 
@@ -112,7 +105,7 @@ def test_create_location_message_coordinates_precision():
     )
 
     assert payload["lat"] == round(payload["lat"], 6)
-    assert payload["lng"] == round(payload["lng"], 6)
+    assert payload["lon"] == round(payload["lon"], 6)
 
 
 def test_create_location_message_speed_between_30_and_50():
@@ -147,21 +140,18 @@ def test_create_location_message_uses_random_speed(monkeypatch):
     assert payload["speed"] == 45
 
 
-def test_create_location_message_valid_crowd_status():
-    payload = create_location_message(
-        bus_id=10,
-        route_id=20,
-        prev_lon=79.8612,
-        prev_lat=6.9271,
-        lon=79.8712,
-        lat=6.9371
+def test_calculate_bearing():
+    bearing = calculate_bearing(
+        79.8612, 6.9271,
+        79.8612, 6.9371  # Moving straight North
     )
+    assert bearing == 0.0
 
-    assert payload["crowdStatus"] in {
-        "NOT_FULL",
-        "SEMI_FULL",
-        "FULL",
-    }
+    bearing_east = calculate_bearing(
+        79.8612, 6.9271,
+        79.8712, 6.9271  # Moving straight East
+    )
+    assert bearing_east == 90.0
 
 
 def test_create_location_message_timestamp_format():
@@ -302,7 +292,7 @@ def test_publish_loop_publishes_status_and_location_messages(monkeypatch):
     start_payload = gps_simulator.json.loads(start_json)
     location_payload = gps_simulator.json.loads(location_json)
 
-    assert start_topic == "transport/bus/10/location"
+    assert start_topic == "transport/bus/10/status"
     assert start_qos == 1
     assert start_payload["type"] == "STATUS"
     assert start_payload["status"] == "STARTED"
@@ -311,9 +301,8 @@ def test_publish_loop_publishes_status_and_location_messages(monkeypatch):
 
     assert location_topic == "transport/bus/10/location"
     assert location_qos == 1
-    assert location_payload["type"] == "LOCATION"
-    assert location_payload["busId"] == 10
-    assert location_payload["routeId"] == 20
+    assert location_payload["busId"] == "10"
+    assert "tripId" in location_payload
     assert loop_stopped is True
     assert disconnected is True
 


### PR DESCRIPTION
- Fix lng -> lon in location messages to match GPSMessage schema - Add tripId to location messages - Add bearing calculation for heading field - Drop routeId, crowdStatus, and type fields from location messages - Publish STATUS messages to transport/bus/{busId}/status instead of /location to avoid breaking validation pipeline - Update unit tests to match new structure