### PR TITLE
feat: validator added for 3 fucntionalities. json parse validation ge…

### DIFF
--- a/services/ingestion/main.py
+++ b/services/ingestion/main.py
@@ -45,7 +45,7 @@ def main():
         print(f"Failed to initialize Kafka producer: {e}")
         # Not exiting yet because Kafka might not be up, or we might want it to retry (KafkaProducer handles this async usually)
 
-    # TODO (Phase 3): Initialize validation engine
+    # Validation engine (Phase 3) is a pure function and requires no initialization
     # TODO (Phase 4): Initialize MQTT subscriber and start loop
     # TODO (Phase 6): Start FastAPI health server in background thread
 

--- a/services/ingestion/tests/test_validator.py
+++ b/services/ingestion/tests/test_validator.py
@@ -1,0 +1,100 @@
+import json
+from datetime import datetime, timezone
+
+from services.ingestion.validator import validate_gps_payload
+
+
+def test_valid_gps_message():
+    """1. Valid GPS message -> success=True, correct GPSMessage returned."""
+    payload = {
+        "busId": "BUS_001",
+        "tripId": "TRIP_001",
+        "lat": 6.9271,
+        "lon": 79.8612,
+        "speed": 45.5,
+        "heading": 120.0,
+        "timestamp": datetime.now(timezone.utc).isoformat()
+    }
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    
+    result = validate_gps_payload(raw_bytes)
+    assert result.success is True
+    assert result.message is not None
+    assert result.message.bus_id == "BUS_001"
+    assert result.message.lat == 6.9271
+
+
+def test_invalid_json():
+    """2. Invalid JSON -> error_type=JSON_PARSE."""
+    raw_bytes = b"not a valid json { string"
+    result = validate_gps_payload(raw_bytes)
+    
+    assert result.success is False
+    assert result.error_type == "JSON_PARSE"
+    assert "Failed to parse JSON" in result.error_reason
+
+
+def test_missing_required_field():
+    """3. Missing required field (no busId) -> error_type=SCHEMA_VALIDATION."""
+    payload = {
+        "tripId": "TRIP_001",
+        "lat": 6.9271,
+        "lon": 79.8612,
+        "speed": 45.5
+    }
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    
+    result = validate_gps_payload(raw_bytes)
+    assert result.success is False
+    assert result.error_type == "SCHEMA_VALIDATION"
+    assert "busId" in result.error_reason or "bus_id" in result.error_reason
+
+
+def test_speed_exceeds_bounds():
+    """4. Speed > 200 -> error_type=SCHEMA_VALIDATION."""
+    payload = {
+        "busId": "BUS_001",
+        "tripId": "TRIP_001",
+        "lat": 6.9271,
+        "lon": 79.8612,
+        "speed": 250.0  # Speed must be <= 200
+    }
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    
+    result = validate_gps_payload(raw_bytes)
+    assert result.success is False
+    assert result.error_type == "SCHEMA_VALIDATION"
+    assert "speed" in result.error_reason
+
+
+def test_coordinates_in_europe():
+    """5. Coordinates in Europe -> error_type=GEO_BOUNDS."""
+    payload = {
+        "busId": "BUS_001",
+        "tripId": "TRIP_001",
+        "lat": 48.8566,  # Paris
+        "lon": 2.3522,
+        "speed": 45.5
+    }
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    
+    result = validate_gps_payload(raw_bytes)
+    assert result.success is False
+    assert result.error_type == "GEO_BOUNDS"
+    assert "out of bounds" in result.error_reason
+
+
+def test_coordinates_on_boundary_edge():
+    """6. Coordinates on boundary edge (lat=5.85 exactly) -> success=True."""
+    payload = {
+        "busId": "BUS_001",
+        "tripId": "TRIP_001",
+        "lat": 5.85,    # Exact min_lat boundary for Sri Lanka
+        "lon": 79.8612,
+        "speed": 45.5
+    }
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    
+    result = validate_gps_payload(raw_bytes)
+    assert result.success is True
+    assert result.message.lat == 5.85

--- a/services/ingestion/validator.py
+++ b/services/ingestion/validator.py
@@ -1,0 +1,57 @@
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+from pydantic import ValidationError
+
+from schemas.geo_config import SRI_LANKA_BOUNDS
+from schemas.gps import GPSMessage
+
+
+@dataclass
+class ValidationResult:
+    success: bool
+    message: Optional[GPSMessage] = None
+    error_reason: Optional[str] = None
+    error_type: Optional[str] = None
+
+
+def validate_gps_payload(raw_bytes: bytes) -> ValidationResult:
+    """
+    Pure function to validate a GPS telemetry payload.
+    No Kafka, no MQTT, no side effects.
+    """
+    # 1. JSON parseable?
+    try:
+        decoded_string = raw_bytes.decode("utf-8")
+        parsed_json = json.loads(decoded_string)
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        return ValidationResult(
+            success=False,
+            error_reason=f"Failed to parse JSON: {str(e)}",
+            error_type="JSON_PARSE"
+        )
+
+    # 2. Matches GPSMessage Pydantic model?
+    try:
+        # Pydantic will validate types, missing required fields, and speed bounds
+        message = GPSMessage.model_validate(parsed_json)
+    except ValidationError as e:
+        # Extract a readable error message from Pydantic
+        errors = e.errors()
+        error_msgs = [f"{err['loc'][0]}: {err['msg']}" if err['loc'] else err['msg'] for err in errors]
+        return ValidationResult(
+            success=False,
+            error_reason=f"Schema validation failed: {'; '.join(error_msgs)}",
+            error_type="SCHEMA_VALIDATION"
+        )
+
+    # 3. Inside SRI_LANKA_BOUNDS?
+    if not SRI_LANKA_BOUNDS.contains(lat=message.lat, lon=message.lon):
+        return ValidationResult(
+            success=False,
+            error_reason=f"Coordinates out of bounds: lat={message.lat}, lon={message.lon}",
+            error_type="GEO_BOUNDS"
+        )
+
+    return ValidationResult(success=True, message=message)


### PR DESCRIPTION
Phase 3 Implementation
 (validator.py): I built the pure validation function validate_gps_payload with zero external dependencies (no Kafka or MQTT). It processes incoming raw bytes through three strict stages:
JSON Parse Check: Traps json.JSONDecodeError returning JSON_PARSE error type.
Schema Validation: Uses Pydantic's GPSMessage.model_validate to enforce data types, missing fields, and speed bounds (returning SCHEMA_VALIDATION).
Geographic Bounds: Uses SRI_LANKA_BOUNDS.contains() to ensure coordinates are physically located in Sri Lanka (returning GEO_BOUNDS).

Wired into main.py: I updated the Phase 3 TODO in your main.py to reflect that the validator is a pure function and requires no upfront initialization.

Validation (test_validator.py): I wrote the exact 6 unit tests specified in your plan covering valid messages, bad JSON, missing busId, speeding limits, coordinates in Europe, and boundary edge cases.