### PR TITLE
feat:extended validation engine by adding stateful checks. 1. Duplica…

### DIFF
--- a/services/ingestion/mqtt_subscriber.py
+++ b/services/ingestion/mqtt_subscriber.py
@@ -3,7 +3,7 @@ import paho.mqtt.client as mqtt
 
 from services.ingestion.config import settings
 from services.ingestion.producer import TelemetryProducer
-from services.ingestion.validator import validate_gps_payload
+from services.ingestion.validator import StatefulValidator
 
 logger = logging.getLogger(__name__)
 
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 class MQTTSubscriber:
     def __init__(self, producer: TelemetryProducer):
         self.producer = producer
+        self.validator = StatefulValidator()
         # Use Protocol v5 or v3.1.1 based on what paho-mqtt defaults to.
         # We specify a clean session for stateless consumption, relying on Kafka for persistence.
         self.client = mqtt.Client(clean_session=True)
@@ -56,7 +57,7 @@ class MQTTSubscriber:
     def on_message(self, client, userdata, msg):
         self.messages_received += 1
         
-        result = validate_gps_payload(msg.payload)
+        result = self.validator.validate(msg.payload)
 
         if result.success and result.message:
             self.messages_validated += 1

--- a/services/ingestion/tests/test_stateful_validator.py
+++ b/services/ingestion/tests/test_stateful_validator.py
@@ -1,0 +1,148 @@
+import json
+import time
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+from services.ingestion.validator import StatefulValidator
+
+
+def test_duplicate_message():
+    """1. Same message twice -> second returns DUPLICATE."""
+    validator = StatefulValidator()
+    
+    payload = {
+        "busId": "BUS_001",
+        "tripId": "TRIP_001",
+        "lat": 6.9271,
+        "lon": 79.8612,
+        "speed": 45.5,
+        "heading": 120.0,
+        "timestamp": datetime.now(timezone.utc).isoformat()
+    }
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    
+    # First message should pass
+    result1 = validator.validate(raw_bytes)
+    assert result1.success is True
+    
+    # Second identical message should be DUPLICATE
+    result2 = validator.validate(raw_bytes)
+    assert result2.success is False
+    assert result2.error_type == "DUPLICATE"
+
+
+def test_rate_limit():
+    """2. Two messages < 1 second apart -> second returns RATE_LIMIT."""
+    validator = StatefulValidator()
+    
+    base_time = datetime.now(timezone.utc)
+    
+    payload1 = {
+        "busId": "BUS_002",
+        "tripId": "TRIP_002",
+        "lat": 6.9271,
+        "lon": 79.8612,
+        "speed": 45.5,
+        "timestamp": base_time.isoformat()
+    }
+    
+    payload2 = {
+        "busId": "BUS_002",
+        "tripId": "TRIP_002",
+        "lat": 6.9280,  # Different location so hash is different
+        "lon": 79.8620,
+        "speed": 46.0,
+        "timestamp": (base_time + timedelta(seconds=2)).isoformat()
+    }
+    
+    # Mock time.monotonic to simulate rapid arrival
+    with patch("services.ingestion.validator.time.monotonic") as mock_time:
+        mock_time.return_value = 100.0
+        
+        # First message
+        result1 = validator.validate(json.dumps(payload1).encode("utf-8"))
+        assert result1.success is True
+        
+        # Second message arrives 0.5 seconds later (rate limited)
+        mock_time.return_value = 100.5
+        result2 = validator.validate(json.dumps(payload2).encode("utf-8"))
+        assert result2.success is False
+        assert result2.error_type == "RATE_LIMIT"
+
+
+def test_out_of_order_sequence():
+    """3. Out-of-order timestamp -> SEQUENCE_ERROR."""
+    validator = StatefulValidator()
+    
+    base_time = datetime.now(timezone.utc)
+    
+    payload1 = {
+        "busId": "BUS_003",
+        "tripId": "TRIP_003",
+        "lat": 6.9271,
+        "lon": 79.8612,
+        "speed": 45.5,
+        "timestamp": base_time.isoformat()
+    }
+    
+    payload2 = {
+        "busId": "BUS_003",
+        "tripId": "TRIP_003",
+        "lat": 6.9280,
+        "lon": 79.8620,
+        "speed": 46.0,
+        # Timestamp is older than payload1
+        "timestamp": (base_time - timedelta(seconds=10)).isoformat()
+    }
+    
+    with patch("services.ingestion.validator.time.monotonic") as mock_time:
+        mock_time.return_value = 100.0
+        
+        # First message
+        result1 = validator.validate(json.dumps(payload1).encode("utf-8"))
+        assert result1.success is True
+        
+        # Second message arrives after 2 seconds (so no rate limit), but is old data
+        mock_time.return_value = 102.0
+        result2 = validator.validate(json.dumps(payload2).encode("utf-8"))
+        assert result2.success is False
+        assert result2.error_type == "SEQUENCE_ERROR"
+
+
+def test_independent_bus_state():
+    """4. Messages from different buses don't interfere with each other's state."""
+    validator = StatefulValidator()
+    
+    base_time = datetime.now(timezone.utc)
+    
+    # Bus A payload
+    payload_a = {
+        "busId": "BUS_A",
+        "tripId": "TRIP_A",
+        "lat": 6.9271,
+        "lon": 79.8612,
+        "speed": 45.5,
+        "timestamp": base_time.isoformat()
+    }
+    
+    # Bus B payload
+    payload_b = {
+        "busId": "BUS_B",
+        "tripId": "TRIP_B",
+        "lat": 6.9280,
+        "lon": 79.8620,
+        "speed": 46.0,
+        "timestamp": (base_time - timedelta(seconds=10)).isoformat()
+    }
+    
+    with patch("services.ingestion.validator.time.monotonic") as mock_time:
+        mock_time.return_value = 100.0
+        
+        # Bus A message
+        result_a = validator.validate(json.dumps(payload_a).encode("utf-8"))
+        assert result_a.success is True
+        
+        # Bus B message arrives instantly (0 seconds apart), but it's a different bus
+        # Also its timestamp is older than Bus A, but it shouldn't matter
+        result_b = validator.validate(json.dumps(payload_b).encode("utf-8"))
+        assert result_b.success is True

--- a/services/ingestion/validator.py
+++ b/services/ingestion/validator.py
@@ -1,6 +1,10 @@
 import json
-from dataclasses import dataclass
-from typing import Optional
+import time
+import hashlib
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional, Dict
 
 from pydantic import ValidationError
 
@@ -55,3 +59,73 @@ def validate_gps_payload(raw_bytes: bytes) -> ValidationResult:
         )
 
     return ValidationResult(success=True, message=message)
+
+
+@dataclass
+class BusIngestionState:
+    last_timestamp: datetime
+    last_receive_time: float
+    recent_hashes: deque = field(default_factory=lambda: deque(maxlen=100))
+
+
+class StatefulValidator:
+    def __init__(self):
+        self._bus_state: Dict[str, BusIngestionState] = {}
+
+    def validate(self, raw_bytes: bytes) -> ValidationResult:
+        # Step 1-3: existing pure validation (JSON, schema, geo)
+        result = validate_gps_payload(raw_bytes)
+        if not result.success or not result.message:
+            return result
+
+        msg = result.message
+        bus_id = msg.bus_id
+        
+        # Step 4: Duplicate detection
+        # Hash = sha256(busId + timestamp + lat + lon)
+        hash_str = f"{bus_id}_{msg.timestamp.isoformat()}_{msg.lat}_{msg.lon}"
+        payload_hash = hashlib.sha256(hash_str.encode("utf-8")).hexdigest()
+
+        state = self._bus_state.get(bus_id)
+        current_time = time.monotonic()
+
+        if state is None:
+            state = BusIngestionState(
+                last_timestamp=msg.timestamp,
+                last_receive_time=current_time
+            )
+            state.recent_hashes.append(payload_hash)
+            self._bus_state[bus_id] = state
+            return result
+
+        if payload_hash in state.recent_hashes:
+            return ValidationResult(
+                success=False,
+                error_reason="Duplicate payload hash detected within recent window",
+                error_type="DUPLICATE"
+            )
+
+        # Step 5: Rate limiting
+        # If last message from same busId was < 1 second ago -> RATE_LIMIT
+        if current_time - state.last_receive_time < 1.0:
+            return ValidationResult(
+                success=False,
+                error_reason=f"Rate limit exceeded for bus {bus_id}",
+                error_type="RATE_LIMIT"
+            )
+
+        # Step 6: Timestamp sequence
+        # If message timestamp <= last timestamp from same busId -> SEQUENCE_ERROR
+        if msg.timestamp <= state.last_timestamp:
+            return ValidationResult(
+                success=False,
+                error_reason=f"Message out of sequence: {msg.timestamp} <= {state.last_timestamp}",
+                error_type="SEQUENCE_ERROR"
+            )
+
+        # All passed -> update bus state
+        state.last_timestamp = msg.timestamp
+        state.last_receive_time = current_time
+        state.recent_hashes.append(payload_hash)
+        
+        return result


### PR DESCRIPTION
 (validator.py): I extended the validation engine by adding the BusIngestionState data class and the core StatefulValidator class. It maintains an in-memory dictionary of states keyed by busId and processes your 3 new checks:

1. Duplicate Detection: Generates a SHA-256 hash of busId + timestamp + lat + lon and checks if it exists in the rolling 100-item deque for that bus.

2. Rate Limiting: Drops messages if they arrive less than 1.0 seconds after the last message from the same bus (using time.monotonic() for precision).

3. Sequence Checking: Drops messages where the telemetry timestamp is older than or equal to the last known timestamp for that bus.
4. 
Wired into mqtt_subscriber.py: I swapped out the pure validate_gps_payload function for the initialized self.validator = StatefulValidator(). 

Subscriber now routes duplicates, rate-limited bursts, and out-of-order packets directly to the DLQ!

Validation (test_stateful_validator.py): I wrote 4 unit tests to rigorously verify all stateful logic. Using time-mocking, the tests proved that duplicates are caught, rapid-fire messages are rate-limited, old sequences are rejected, and state remains perfectly isolated between different buses.