### PR TITLE
Fix/ingestion p7 p8

### DIFF
--- a/services/ingestion/README.md
+++ b/services/ingestion/README.md
@@ -171,6 +171,9 @@ Fleet must publish the same `busId` value that G1 publishes.
 DLQ envelope includes:
 
 - original payload
+- `busId` when parseable from payload or topic
+- `tripId` when parseable from payload
+- event timestamp when parseable from payload
 - error reason
 - error type
 - source
@@ -253,8 +256,11 @@ curl http://localhost:8001/metrics
 
 - `docker compose` includes `ingestion-service`
 - image starts with `python -m services.ingestion.app.main`
-- readiness endpoint returns `200` only when Kafka and MQTT are connected
+- readiness endpoint returns `200` only when Kafka, MQTT, and the required
+  active-trip cache are ready
 - liveness endpoint stays available while the service process is alive
+- `/metrics` exposes each typed GPS rejection reason and trip-cache gauges
+- DLQ messages include safe metadata even when the original payload is invalid
 - ingestion tests pass locally
 - docs describe G1 and G4 integration points
 

--- a/services/ingestion/README.md
+++ b/services/ingestion/README.md
@@ -1,86 +1,41 @@
 # Ingestion Service
 
-The ingestion service is G2's MQTT-to-Kafka gateway. It accepts GPS telemetry from G1, validates it against the shared `GPSLocationMessage` input contract, enriches accepted active-trip telemetry into `GPSMessage`, applies stateful filtering, and forwards clean data to Kafka for downstream stream processing.
+The ingestion service is G2's MQTT-to-Kafka boundary for live bus telemetry. It
+receives GPS from G1, validates the payload, checks that the bus has an active
+Fleet trip, enriches accepted GPS with `tripId`, and publishes clean telemetry
+to Kafka. Bad GPS goes to the DLQ with typed reasons and useful metadata.
 
-## What Phase 7 Completes
-
-- packages runtime code under `services/ingestion/app/`
-- adds a Docker image entrypoint for the full worker
-- integrates `ingestion-service` into `docker/docker-compose.yml`
-- exposes liveness and readiness probes for operations
-- documents the G1 and G4 integration interfaces clearly
-
-## Runtime Flow
+## End-to-End Flow
 
 ```text
-G1 GPS device / simulator
-  -> MQTT broker (Mosquitto)
-  -> ingestion-service
-     -> schema validation
-     -> geo validation
-     -> duplicate / rate / sequence checks
-     -> valid message -> Kafka raw topic
-     -> invalid message -> Kafka DLQ topic
+Fleet start trip
+  -> Kafka trip.lifecycle
+  -> ingestion active-trip cache
+
+G1 GPS device
+  -> MQTT transport/bus/{busId}/location
+  -> ingestion schema/geo/trip/event-time validation
+  -> Kafka transport-telemetry-raw
+  -> stream processing / live map
+
+Invalid or inactive GPS
+  -> Kafka transport-telemetry-dlq
+
+G1 heartbeat
+  -> MQTT transport/bus/{busId}/heartbeat
+  -> ingestion metrics only
 ```
 
-## Directory Layout
+## Contracts
 
-```text
-services/ingestion/
-  app/
-    config.py
-    health.py
-    main.py
-    metrics.py
-    mqtt_subscriber.py
-    producer.py
-    validator.py
-  tests/
-  Dockerfile
-  requirements.txt
-  README.md
-```
+### MQTT Topics
 
-## Responsibilities
+| Purpose | G1 publish topic | Ingestion subscribe pattern | Retained |
+|---------|------------------|-----------------------------|----------|
+| Live GPS | `transport/bus/{busId}/location` | `transport/bus/+/location` | `false` |
+| Device heartbeat | `transport/bus/{busId}/heartbeat` | `transport/bus/+/heartbeat` | allowed if timestamped |
 
-- subscribe to MQTT topic `transport/bus/+/location`
-- validate JSON and `GPSLocationMessage` schema from G1
-- reject coordinates outside Sri Lanka bounds
-- detect duplicates from the same bus
-- enforce minimum message interval per bus
-- reject out-of-order timestamps per bus
-- publish valid messages to Kafka topic `transport-telemetry-raw`
-- publish invalid messages to Kafka topic `transport-telemetry-dlq`
-- expose `/health`, `/health/live`, `/health/ready`, and `/metrics`
-
-## Interfaces
-
-### G1 -> G2 ingestion interface
-
-| Item | Value |
-|------|-------|
-| Producer group | G1 Device & Edge |
-| Protocol | MQTT 3.1.1 |
-| Transport | Local Mosquitto by default; HiveMQ-compatible config planned |
-| Topic | `transport/bus/{busId}/location` |
-| G1 payload contract | `busId`, `lat`, `lon`, `speed`, `heading`, `timestamp` |
-| Accepted raw Kafka contract | `GPSMessage` after ingestion enriches active `tripId` |
-| Expected publish cadence | every 3 to 5 seconds per active bus |
-| Current dev publisher | `scripts/gps_simulator.py` |
-
-Frozen contract decisions:
-
-- G1 must not send `tripId`; ingestion resolves it from `busId` plus Kafka `trip.lifecycle`.
-- `busId` is the Fleet bus `id`, serialized as a string, for example `"1"`.
-- `timestamp` is required and must be ISO 8601 UTC, for example `"2026-05-02T10:15:30Z"`.
-- `speed` is reported in km/h.
-- `heading` is degrees from `0` to `360`; if the GPS course is invalid or stationary, send `0`.
-- G1 location publishes must use retained=false.
-- Heartbeat may use retained=true only if it is timestamped and treated as device status, not live movement.
-- Inactive GPS is rejected to DLQ with `INACTIVE_TRIP`.
-- Startup cache rebuild must not create false `INACTIVE_TRIP` DLQ entries.
-
-Location payload sent by G1:
+G1 GPS payload:
 
 ```json
 {
@@ -93,31 +48,16 @@ Location payload sent by G1:
 }
 ```
 
-Accepted raw Kafka payload after ingestion enrichment:
+Rules:
 
-```json
-{
-  "busId": "1",
-  "tripId": "TRIP-001",
-  "lat": 6.9271,
-  "lon": 79.8612,
-  "speed": 35.0,
-  "heading": 120.0,
-  "timestamp": "2026-05-02T10:15:30Z"
-}
-```
+- `busId` is the Fleet bus id serialized as a string.
+- G1 does not send `tripId`; ingestion adds it from `trip.lifecycle`.
+- `timestamp` is required ISO 8601 UTC event time.
+- `speed` is km/h.
+- `heading` is degrees from `0` to `360`.
+- live GPS must not be retained, because retained GPS can replay stale movement.
 
-Heartbeat topic:
-
-```text
-transport/bus/{busId}/heartbeat
-```
-
-Heartbeat is separate from live GPS and must not be published to
-`transport-telemetry-raw`. In Increment 1 ingestion records heartbeat metrics
-only; it does not publish heartbeat messages to Kafka.
-
-Heartbeat payload sent by G1:
+Heartbeat payload:
 
 ```json
 {
@@ -132,19 +72,18 @@ Heartbeat payload sent by G1:
 }
 ```
 
-Warnings such as "trip started but no GPS device signal" should be generated by
-Fleet/anomaly monitoring using trip lifecycle plus heartbeat/GPS absence. GPS
-received without an active trip continues to go to DLQ with `INACTIVE_TRIP`.
+Heartbeat is device status only. It is not published to
+`transport-telemetry-raw`.
 
-Planned event-time validation thresholds:
+### Kafka Topics
 
-| Variable | Value | Meaning |
-|----------|-------|---------|
-| `INGESTION_MIN_EVENT_INTERVAL_SECONDS` | `1.0` | minimum event-time gap accepted per bus |
-| `INGESTION_MAX_FUTURE_SKEW_SECONDS` | `30` | maximum allowed future clock skew |
-| `INGESTION_MAX_STALE_AGE_SECONDS` | `86400` | maximum stale replay age in seconds |
+| Topic | Producer | Consumer | Purpose |
+|-------|----------|----------|---------|
+| `trip.lifecycle` | Fleet Management | ingestion, stream processing | active trip start/end events |
+| `transport-telemetry-raw` | ingestion | stream processing | accepted active-trip GPS |
+| `transport-telemetry-dlq` | ingestion | operators/anomaly tooling | rejected GPS with reason metadata |
 
-Trip lifecycle dependency:
+Trip lifecycle start event:
 
 ```json
 {
@@ -156,94 +95,139 @@ Trip lifecycle dependency:
 }
 ```
 
-Fleet must publish the same `busId` value that G1 publishes.
+`TRIP_ENDED` with the same `busId` and `tripId` removes the bus from the active
+trip cache.
 
-### G2 ingestion -> downstream G2 interface
+Accepted raw Kafka GPS after ingestion enrichment:
 
-| Item | Value |
-|------|-------|
-| Consumer | stream-processing / downstream Kafka consumers |
-| Protocol | Kafka |
-| Valid topic | `transport-telemetry-raw` |
-| Invalid topic | `transport-telemetry-dlq` |
-| Keying | valid messages keyed by `busId` |
+```json
+{
+  "busId": "1",
+  "tripId": "TRIP-001",
+  "lat": 6.9271,
+  "lon": 79.8612,
+  "speed": 35.0,
+  "heading": 120.0,
+  "timestamp": "2026-05-02T10:15:30Z"
+}
+```
 
 DLQ envelope includes:
 
-- original payload
-- `busId` when parseable from payload or topic
-- `tripId` when parseable from payload
-- event timestamp when parseable from payload
-- error reason
-- error type
-- source
-- source topic
-- received timestamp
+- `original_payload`
+- `busId` if parseable from payload or topic
+- `tripId` if parseable from payload
+- `event_timestamp` if parseable from payload
+- `error_type`
+- `error_reason`
+- `source`
+- `source_topic`
+- `received_at`
 
-### G4 -> G2 ingestion interface
+Current GPS rejection reasons:
 
-| Item | Value |
-|------|-------|
-| Consumer group | G4 Platform, Security & Integration |
-| Access method | Docker Compose / container runtime / HTTP scrape |
-| Health summary | `GET /health` |
-| Liveness probe | `GET /health/live` |
-| Readiness probe | `GET /health/ready` |
-| Metrics scrape | `GET /metrics` |
-| Default service port | `8001` |
+`JSON_PARSE`, `MISSING_TIMESTAMP`, `SCHEMA_VALIDATION`, `GEO_BOUNDS`,
+`INACTIVE_TRIP`, `TRIP_CACHE_REBUILDING`, `DUPLICATE`,
+`RATE_LIMIT`, `RATE_LIMIT_EVENT_TIME`, `SEQUENCE_ERROR`,
+`FUTURE_TIMESTAMP`, `STALE_REPLAY`.
 
-G4 uses these interfaces for:
+## HTTP Endpoints
 
-- container health monitoring
-- orchestrator readiness checks
-- Prometheus scraping
-- debugging dependency failures
+| Endpoint | Meaning |
+|----------|---------|
+| `GET /health` | dependency-aware service summary |
+| `GET /health/live` | process liveness |
+| `GET /health/ready` | readiness for Kafka, MQTT, and trip-cache state |
+| `GET /metrics` | Prometheus-style counters and gauges |
 
-## Environment Variables
+Readiness returns `200` only when Kafka is up, MQTT is up, and the active-trip
+cache is ready when `INGESTION_REQUIRE_ACTIVE_TRIP=true`.
+
+## Validation Rules
+
+Ingestion accepts a GPS message only when all checks pass:
+
+1. payload is UTF-8 JSON object
+2. required `timestamp` exists
+3. payload matches `GPSLocationMessage`
+4. coordinates are inside Sri Lanka bounds
+5. cache is ready, or the message is buffered during startup rebuild
+6. bus has an active trip in the local cache
+7. enriched GPS passes future/stale, duplicate, sequence, and event-time interval checks
+
+Event-time defaults:
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `INGESTION_MIN_EVENT_INTERVAL_SECONDS` | `1.0` | minimum event-time gap per bus |
+| `INGESTION_MAX_FUTURE_SKEW_SECONDS` | `30.0` | allowed future clock skew |
+| `INGESTION_MAX_STALE_AGE_SECONDS` | `86400.0` | allowed stale replay age |
+| `INGESTION_DUPLICATE_CACHE_SIZE` | `100` | recent payload hashes per bus |
+
+## Configuration
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MQTT_BROKER_HOST` | `mqtt-broker` | MQTT broker host |
 | `MQTT_BROKER_PORT` | `1883` | MQTT broker port |
-| `MQTT_TOPIC_PATTERN` | `transport/bus/+/location` | MQTT subscription pattern |
-| `MQTT_HEARTBEAT_TOPIC_PATTERN` | `transport/bus/+/heartbeat` | MQTT heartbeat subscription pattern |
-| `MQTT_TLS_ENABLED` | `false` | enable TLS for HiveMQ-style brokers |
+| `MQTT_TOPIC_PATTERN` | `transport/bus/+/location` | GPS subscription pattern |
+| `MQTT_HEARTBEAT_TOPIC_PATTERN` | `transport/bus/+/heartbeat` | heartbeat subscription pattern |
+| `MQTT_TLS_ENABLED` | `false` | enable TLS for secured brokers |
 | `MQTT_USERNAME` | unset | optional MQTT username |
 | `MQTT_PASSWORD` | unset | optional MQTT password |
-| `MQTT_CLIENT_ID` | `ontime-ingestion-service` | MQTT client identifier |
-| `MQTT_CA_CERT_PATH` | unset | optional CA certificate path for MQTT TLS |
+| `MQTT_CLIENT_ID` | `ontime-ingestion-service` | MQTT client id |
+| `MQTT_CA_CERT_PATH` | unset | optional TLS CA certificate path |
 | `KAFKA_BROKER_URL` | `broker:29092` | Kafka bootstrap server |
-| `INGESTION_KAFKA_RAW_TOPIC` | `transport-telemetry-raw` | topic for accepted telemetry |
-| `INGESTION_KAFKA_DLQ_TOPIC` | `transport-telemetry-dlq` | topic for rejected telemetry |
-| `INGESTION_SERVICE_PORT` | `8001` | port used by health and metrics server |
-| `INGESTION_MIN_MESSAGE_INTERVAL_SECONDS` | `3.0` | minimum accepted gap between messages from the same bus |
-| `INGESTION_DUPLICATE_CACHE_SIZE` | `100` | duplicate hash window per bus |
+| `INGESTION_KAFKA_RAW_TOPIC` | `transport-telemetry-raw` | accepted GPS topic |
+| `INGESTION_KAFKA_DLQ_TOPIC` | `transport-telemetry-dlq` | rejected GPS topic |
+| `INGESTION_KAFKA_TRIP_LIFECYCLE_TOPIC` | `trip.lifecycle` | trip lifecycle topic |
+| `INGESTION_TRIP_CACHE_CONSUMER_GROUP` | `ingestion-trip-cache` | lifecycle consumer group |
+| `INGESTION_REQUIRE_ACTIVE_TRIP` | `true` | reject GPS without active trip |
+| `INGESTION_TRIP_CACHE_REBUILD_TIMEOUT_SECONDS` | `60.0` | startup cache rebuild window |
+| `INGESTION_STARTUP_BUFFER_MAX_MESSAGES` | `1000` | GPS buffer during cache rebuild |
+| `INGESTION_SERVICE_PORT` | `8001` | health/metrics port |
 
-## Local Run
+`INGESTION_` aliases are preferred in deployment, but legacy names such as
+`MQTT_BROKER_HOST` and `KAFKA_BROKER_URL` are still accepted.
 
-From the repo root:
+## Code Map
+
+| File | Main methods/classes | What they do |
+|------|----------------------|--------------|
+| `app/main.py` | `main`, `handle_shutdown` | starts producer, trip cache consumer, MQTT subscriber, and health server; shuts them down cleanly |
+| `app/config.py` | `IngestionSettings` | loads env config and defaults |
+| `app/mqtt_subscriber.py` | `MQTTSubscriber.connect/start/stop` | manages MQTT connection and loop |
+| `app/mqtt_subscriber.py` | `on_connect`, `on_disconnect`, `on_message` | subscribes to GPS/heartbeat topics and routes incoming messages |
+| `app/mqtt_subscriber.py` | `_process_payload` | validates GPS, buffers during cache rebuild, enriches with tripId, publishes valid/DLQ |
+| `app/mqtt_subscriber.py` | `_process_heartbeat` | validates heartbeat and records metrics only |
+| `app/mqtt_subscriber.py` | `_enrich_location`, `_reject` | attaches active `tripId`; sends rejected payloads to DLQ |
+| `app/validator.py` | `validate_gps_location_payload` | validates G1 MQTT GPS without `tripId` |
+| `app/validator.py` | `validate_gps_payload` | validates enriched Kafka GPS with required `tripId` |
+| `app/validator.py` | `validate_heartbeat_payload` | validates heartbeat device status |
+| `app/validator.py` | `StatefulValidator.validate` | checks future/stale timestamps, duplicates, order, and event-time interval |
+| `app/trip_lifecycle_cache.py` | `ActiveTripCache.apply_event/get_active_trip` | maintains busId -> active trip in memory |
+| `app/trip_lifecycle_cache.py` | `TripLifecycleConsumer.start/stop` | consumes `trip.lifecycle` in a background thread |
+| `app/producer.py` | `publish_valid` | publishes accepted GPS to `transport-telemetry-raw` keyed by `busId` |
+| `app/producer.py` | `publish_to_dlq` | publishes rejected GPS to `transport-telemetry-dlq` with metadata |
+| `app/metrics.py` | `MetricsCollector` methods | tracks received, accepted, rejected, heartbeat, broker, and trip-cache metrics |
+| `app/health.py` | `create_app`, `start_health_server` | exposes `/health`, `/health/live`, `/health/ready`, and `/metrics` |
+
+## Run
+
+Local Python:
 
 ```bash
 python -m pip install -r services/ingestion/requirements.txt
 python -m services.ingestion.app.main
 ```
 
-## Docker Compose Run
-
-From the repo root:
+Docker Compose:
 
 ```bash
 docker compose -f docker/docker-compose.yml up -d broker mqtt-broker ingestion-service
 ```
 
-Compose listener map:
-
-- Kafka inside Docker network: `broker:29092`
-- Kafka from host machine: `localhost:9092`
-- MQTT from host machine: `localhost:1883`
-- Ingestion health/metrics from host machine: `localhost:8001`
-
-Useful checks:
+Useful host checks:
 
 ```bash
 curl http://localhost:8001/health
@@ -252,48 +236,27 @@ curl http://localhost:8001/health/ready
 curl http://localhost:8001/metrics
 ```
 
-## Phase 7 Validation Checklist
-
-- `docker compose` includes `ingestion-service`
-- image starts with `python -m services.ingestion.app.main`
-- readiness endpoint returns `200` only when Kafka, MQTT, and the required
-  active-trip cache are ready
-- liveness endpoint stays available while the service process is alive
-- `/metrics` exposes each typed GPS rejection reason and trip-cache gauges
-- DLQ messages include safe metadata even when the original payload is invalid
-- ingestion tests pass locally
-- docs describe G1 and G4 integration points
-
 ## Tests
 
 ```bash
 python -m pip install -r services/ingestion/requirements-dev.txt
-python -m pytest services/ingestion/tests/unit -v --cov=services/ingestion/app --cov-report=term-missing
-python -m pytest services/ingestion/tests/integration -m integration -v
-pytest services/ingestion/tests -v
+python -m pytest services/ingestion/tests/unit -q
+python -m pytest services/ingestion/tests/integration/test_smoke_pipeline.py -q
 ```
 
-Unit test coverage includes heartbeat parsing without raw GPS Kafka output.
+Smoke coverage proves:
 
-Smoke test coverage includes:
+- Kafka, Mosquitto, and ingestion containers start
+- `TRIP_STARTED` is consumed into the active-trip cache
+- valid MQTT GPS reaches `transport-telemetry-raw` with enriched `tripId`
+- invalid MQTT GPS reaches `transport-telemetry-dlq`
+- `/health/ready` works in the container stack
 
-- containerized Kafka broker
-- containerized Mosquitto broker
-- ingestion service startup and readiness
-- MQTT publish of valid and invalid telemetry
-- assertion that raw data reaches Kafka raw topic
-- assertion that invalid data reaches Kafka DLQ
+## Ownership Notes
 
-## Important Notes
-
-- The service is intentionally narrow in scope. It does not calculate ETA, render maps, or own user-facing APIs.
-- `services/ingestion/app/` is the runtime package. Tests stay under `services/ingestion/tests/`.
-- Unit tests live under `services/ingestion/tests/unit/`.
-- Docker-backed smoke tests live under `services/ingestion/tests/integration/`.
-- `services/ingestion/tests/conftest.py` is only a pytest path helper for this service's tests. It is not part of the runtime.
-
-## Ownership
-
-- Owner: Janidu
-- Downstream reviewer: Natasha
-- Infrastructure reviewer: Kusal
+- Fleet owns trip start/end and publishes `trip.lifecycle`.
+- G1 owns GPS and heartbeat publishing.
+- Ingestion owns validation, active-trip gating, raw Kafka publish, DLQ publish,
+  health, and metrics.
+- Stream processing owns downstream route enrichment, ETA, anomaly, and live map
+  outputs.

--- a/services/ingestion/app/health.py
+++ b/services/ingestion/app/health.py
@@ -4,21 +4,42 @@ from fastapi import FastAPI, status
 from fastapi.responses import JSONResponse, PlainTextResponse
 
 from services.ingestion.app.config import settings
-from services.ingestion.app.metrics import metrics
+from services.ingestion.app.metrics import REJECTION_REASONS, metrics
+
+
+def _trip_cache_ready(snapshot: dict) -> bool:
+    if not settings.require_active_trip:
+        return True
+    return snapshot["trip_cache_status"] == "ready"
+
+
+def _dependencies_ready(snapshot: dict) -> bool:
+    return (
+        snapshot["kafka_broker_up"]
+        and snapshot["mqtt_broker_up"]
+        and _trip_cache_ready(snapshot)
+    )
 
 
 def _build_health_payload(snapshot: dict) -> dict:
     kafka_ok = snapshot["kafka_broker_up"]
     mqtt_ok = snapshot["mqtt_broker_up"]
+    dependencies_ok = _dependencies_ready(snapshot)
 
     return {
-        "status": "healthy" if (kafka_ok and mqtt_ok) else "degraded",
+        "status": "healthy" if dependencies_ok else "degraded",
         "service": "ingestion-service",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "dependencies": {
             "kafka_broker": "up" if kafka_ok else "down",
             "mqtt_broker": "up" if mqtt_ok else "down",
             "trip_cache": snapshot["trip_cache_status"],
+        },
+        "trip_cache": {
+            "ready": _trip_cache_ready(snapshot),
+            "status": snapshot["trip_cache_status"],
+            "active_trip_count": snapshot["active_trip_count"],
+            "last_lifecycle_event_timestamp": snapshot["last_trip_lifecycle_time"],
         },
         "counters": {
             "messages_received": snapshot["messages_received"],
@@ -59,7 +80,7 @@ def create_app():
         payload = _build_health_payload(snapshot)
         status_code = (
             status.HTTP_200_OK
-            if snapshot["kafka_broker_up"] and snapshot["mqtt_broker_up"]
+            if _dependencies_ready(snapshot)
             else status.HTTP_503_SERVICE_UNAVAILABLE
         )
         return JSONResponse(status_code=status_code, content=payload)
@@ -96,18 +117,21 @@ def create_app():
             "",
             "# HELP ingestion_messages_rejected_total Total messages rejected by error type",
             "# TYPE ingestion_messages_rejected_total counter",
-            f'ingestion_messages_rejected_total{{reason="JSON_PARSE"}} {snapshot["messages_rejected_json"]}',
-            f'ingestion_messages_rejected_total{{reason="MISSING_TIMESTAMP"}} {snapshot["messages_rejected_missing_timestamp"]}',
-            f'ingestion_messages_rejected_total{{reason="SCHEMA_VALIDATION"}} {snapshot["messages_rejected_schema"]}',
-            f'ingestion_messages_rejected_total{{reason="GEO_BOUNDS"}} {snapshot["messages_rejected_geo"]}',
-            f'ingestion_messages_rejected_total{{reason="DUPLICATE"}} {snapshot["messages_rejected_duplicate"]}',
-            f'ingestion_messages_rejected_total{{reason="INACTIVE_TRIP"}} {snapshot["messages_rejected_inactive_trip"]}',
-            f'ingestion_messages_rejected_total{{reason="TRIP_CACHE_REBUILDING"}} {snapshot["messages_rejected_trip_cache_rebuilding"]}',
-            f'ingestion_messages_rejected_total{{reason="RATE_LIMIT"}} {snapshot["messages_rejected_rate_limit"]}',
-            f'ingestion_messages_rejected_total{{reason="RATE_LIMIT_EVENT_TIME"}} {snapshot["messages_rejected_rate_limit_event_time"]}',
-            f'ingestion_messages_rejected_total{{reason="SEQUENCE_ERROR"}} {snapshot["messages_rejected_sequence"]}',
-            f'ingestion_messages_rejected_total{{reason="FUTURE_TIMESTAMP"}} {snapshot["messages_rejected_future_timestamp"]}',
-            f'ingestion_messages_rejected_total{{reason="STALE_REPLAY"}} {snapshot["messages_rejected_stale_replay"]}',
+            *[
+                (
+                    f'ingestion_messages_rejected_total{{reason="{reason}"}} '
+                    f'{snapshot["rejections_by_reason"][reason]}'
+                )
+                for reason in REJECTION_REASONS
+            ],
+            "",
+            "# HELP ingestion_trip_cache_ready Active trip cache readiness (1=ready, 0=not ready)",
+            "# TYPE ingestion_trip_cache_ready gauge",
+            f'ingestion_trip_cache_ready {1 if _trip_cache_ready(snapshot) else 0}',
+            "",
+            "# HELP ingestion_trip_cache_active_trips Active trips currently cached",
+            "# TYPE ingestion_trip_cache_active_trips gauge",
+            f'ingestion_trip_cache_active_trips {snapshot["active_trip_count"]}',
             "",
             "# HELP ingestion_uptime_seconds Service uptime in seconds",
             "# TYPE ingestion_uptime_seconds gauge",

--- a/services/ingestion/app/metrics.py
+++ b/services/ingestion/app/metrics.py
@@ -3,6 +3,37 @@ from datetime import datetime, timezone
 from time import time
 
 
+REJECTION_REASONS = (
+    "JSON_PARSE",
+    "MISSING_TIMESTAMP",
+    "SCHEMA_VALIDATION",
+    "GEO_BOUNDS",
+    "DUPLICATE",
+    "INACTIVE_TRIP",
+    "TRIP_CACHE_REBUILDING",
+    "RATE_LIMIT",
+    "RATE_LIMIT_EVENT_TIME",
+    "SEQUENCE_ERROR",
+    "FUTURE_TIMESTAMP",
+    "STALE_REPLAY",
+)
+
+REJECTION_REASON_SNAPSHOT_KEYS = {
+    "JSON_PARSE": "messages_rejected_json",
+    "MISSING_TIMESTAMP": "messages_rejected_missing_timestamp",
+    "SCHEMA_VALIDATION": "messages_rejected_schema",
+    "GEO_BOUNDS": "messages_rejected_geo",
+    "DUPLICATE": "messages_rejected_duplicate",
+    "INACTIVE_TRIP": "messages_rejected_inactive_trip",
+    "TRIP_CACHE_REBUILDING": "messages_rejected_trip_cache_rebuilding",
+    "RATE_LIMIT": "messages_rejected_rate_limit",
+    "RATE_LIMIT_EVENT_TIME": "messages_rejected_rate_limit_event_time",
+    "SEQUENCE_ERROR": "messages_rejected_sequence",
+    "FUTURE_TIMESTAMP": "messages_rejected_future_timestamp",
+    "STALE_REPLAY": "messages_rejected_stale_replay",
+}
+
+
 class MetricsCollector:
     """Thread-safe metrics collection for ingestion."""
 
@@ -12,18 +43,7 @@ class MetricsCollector:
         self.heartbeat_messages_received = 0
         self.heartbeat_messages_invalid = 0
         self.latest_heartbeat_by_bus: dict[str, datetime] = {}
-        self.messages_rejected_json = 0
-        self.messages_rejected_missing_timestamp = 0
-        self.messages_rejected_schema = 0
-        self.messages_rejected_geo = 0
-        self.messages_rejected_duplicate = 0
-        self.messages_rejected_inactive_trip = 0
-        self.messages_rejected_trip_cache_rebuilding = 0
-        self.messages_rejected_rate_limit = 0
-        self.messages_rejected_rate_limit_event_time = 0
-        self.messages_rejected_sequence = 0
-        self.messages_rejected_future_timestamp = 0
-        self.messages_rejected_stale_replay = 0
+        self.rejections_by_reason = {reason: 0 for reason in REJECTION_REASONS}
 
         self.start_time = time()
         self.last_message_time = 0.0
@@ -58,30 +78,8 @@ class MetricsCollector:
 
     def increment_rejected(self, error_type: str):
         with self._lock:
-            if error_type == "JSON_PARSE":
-                self.messages_rejected_json += 1
-            elif error_type == "MISSING_TIMESTAMP":
-                self.messages_rejected_missing_timestamp += 1
-            elif error_type == "SCHEMA_VALIDATION":
-                self.messages_rejected_schema += 1
-            elif error_type == "GEO_BOUNDS":
-                self.messages_rejected_geo += 1
-            elif error_type == "DUPLICATE":
-                self.messages_rejected_duplicate += 1
-            elif error_type == "INACTIVE_TRIP":
-                self.messages_rejected_inactive_trip += 1
-            elif error_type == "TRIP_CACHE_REBUILDING":
-                self.messages_rejected_trip_cache_rebuilding += 1
-            elif error_type == "RATE_LIMIT":
-                self.messages_rejected_rate_limit += 1
-            elif error_type == "RATE_LIMIT_EVENT_TIME":
-                self.messages_rejected_rate_limit_event_time += 1
-            elif error_type == "SEQUENCE_ERROR":
-                self.messages_rejected_sequence += 1
-            elif error_type == "FUTURE_TIMESTAMP":
-                self.messages_rejected_future_timestamp += 1
-            elif error_type == "STALE_REPLAY":
-                self.messages_rejected_stale_replay += 1
+            if error_type in self.rejections_by_reason:
+                self.rejections_by_reason[error_type] += 1
 
     def update_trip_cache(
         self,
@@ -100,25 +98,18 @@ class MetricsCollector:
 
     def total_rejected(self) -> int:
         with self._lock:
-            return (
-                self.messages_rejected_json
-                + self.messages_rejected_missing_timestamp
-                + self.messages_rejected_schema
-                + self.messages_rejected_geo
-                + self.messages_rejected_duplicate
-                + self.messages_rejected_inactive_trip
-                + self.messages_rejected_trip_cache_rebuilding
-                + self.messages_rejected_rate_limit
-                + self.messages_rejected_rate_limit_event_time
-                + self.messages_rejected_sequence
-                + self.messages_rejected_future_timestamp
-                + self.messages_rejected_stale_replay
-            )
+            return sum(self.rejections_by_reason.values())
+
+    def _legacy_rejection_snapshot(self) -> dict:
+        return {
+            snapshot_key: self.rejections_by_reason[reason]
+            for reason, snapshot_key in REJECTION_REASON_SNAPSHOT_KEYS.items()
+        }
 
     def get_snapshot(self) -> dict:
         with self._lock:
             now = datetime.now(timezone.utc)
-            return {
+            snapshot = {
                 "messages_received": self.messages_received,
                 "messages_validated": self.messages_validated,
                 "heartbeat_messages_received": self.heartbeat_messages_received,
@@ -132,22 +123,7 @@ class MetricsCollector:
                     for bus_id, timestamp in self.latest_heartbeat_by_bus.items()
                 },
                 "messages_rejected": self.total_rejected(),
-                "messages_rejected_json": self.messages_rejected_json,
-                "messages_rejected_missing_timestamp": self.messages_rejected_missing_timestamp,
-                "messages_rejected_schema": self.messages_rejected_schema,
-                "messages_rejected_geo": self.messages_rejected_geo,
-                "messages_rejected_duplicate": self.messages_rejected_duplicate,
-                "messages_rejected_inactive_trip": self.messages_rejected_inactive_trip,
-                "messages_rejected_trip_cache_rebuilding": (
-                    self.messages_rejected_trip_cache_rebuilding
-                ),
-                "messages_rejected_rate_limit": self.messages_rejected_rate_limit,
-                "messages_rejected_rate_limit_event_time": (
-                    self.messages_rejected_rate_limit_event_time
-                ),
-                "messages_rejected_sequence": self.messages_rejected_sequence,
-                "messages_rejected_future_timestamp": self.messages_rejected_future_timestamp,
-                "messages_rejected_stale_replay": self.messages_rejected_stale_replay,
+                "rejections_by_reason": dict(self.rejections_by_reason),
                 "uptime_seconds": self.get_uptime_seconds(),
                 "kafka_broker_up": self.kafka_broker_up,
                 "mqtt_broker_up": self.mqtt_broker_up,
@@ -155,6 +131,8 @@ class MetricsCollector:
                 "active_trip_count": self.active_trip_count,
                 "last_trip_lifecycle_time": self.last_trip_lifecycle_time,
             }
+            snapshot.update(self._legacy_rejection_snapshot())
+            return snapshot
 
 
 metrics = MetricsCollector()

--- a/services/ingestion/app/producer.py
+++ b/services/ingestion/app/producer.py
@@ -10,6 +10,69 @@ from services.ingestion.app.config import settings
 logger = logging.getLogger(__name__)
 
 
+def _as_utc_isoformat(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _parse_event_timestamp(value) -> str | None:
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        return _as_utc_isoformat(value)
+
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()
+        except (OSError, OverflowError, ValueError):
+            return None
+
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return _as_utc_isoformat(parsed)
+
+    return None
+
+
+def _bus_id_from_topic(source_topic: str) -> str | None:
+    topic_parts = source_topic.split("/")
+    if len(topic_parts) >= 3 and topic_parts[0] == "transport" and topic_parts[1] == "bus":
+        return topic_parts[2] or None
+    return None
+
+
+def _extract_dlq_metadata(raw_payload: bytes, source_topic: str) -> dict:
+    metadata = {
+        "busId": _bus_id_from_topic(source_topic),
+        "tripId": None,
+        "event_timestamp": None,
+    }
+
+    try:
+        parsed = json.loads(raw_payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return metadata
+
+    if not isinstance(parsed, dict):
+        return metadata
+
+    bus_id = parsed.get("busId") or parsed.get("bus_id")
+    if bus_id is not None:
+        metadata["busId"] = str(bus_id)
+
+    trip_id = parsed.get("tripId") or parsed.get("trip_id")
+    if trip_id is not None:
+        metadata["tripId"] = str(trip_id)
+
+    metadata["event_timestamp"] = _parse_event_timestamp(parsed.get("timestamp"))
+    return metadata
+
+
 class TelemetryProducer:
     def __init__(self):
         self.producer = KafkaProducer(
@@ -38,8 +101,12 @@ class TelemetryProducer:
         source_topic: str,
     ):
         """Publish an invalid message to the DLQ with metadata."""
+        metadata = _extract_dlq_metadata(raw_payload, source_topic)
         envelope = {
             "original_payload": raw_payload.decode("utf-8", errors="replace"),
+            "busId": metadata["busId"],
+            "tripId": metadata["tripId"],
+            "event_timestamp": metadata["event_timestamp"],
             "error_reason": error_reason,
             "error_type": error_type,
             "source": "mqtt",

--- a/services/ingestion/tests/unit/test_health_metrics.py
+++ b/services/ingestion/tests/unit/test_health_metrics.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import services.ingestion.app.health as health_module
-from services.ingestion.app.metrics import MetricsCollector
+from services.ingestion.app.metrics import REJECTION_REASONS, MetricsCollector
 
 
 class TestMetricsCollectorCore:
@@ -46,20 +46,13 @@ class TestMetricsCollectorCore:
 
     def test_increment_rejected_types(self):
         collector = MetricsCollector()
-        collector.increment_rejected("JSON_PARSE")
-        collector.increment_rejected("MISSING_TIMESTAMP")
-        collector.increment_rejected("SCHEMA_VALIDATION")
-        collector.increment_rejected("GEO_BOUNDS")
-        collector.increment_rejected("DUPLICATE")
-        collector.increment_rejected("RATE_LIMIT")
-        collector.increment_rejected("RATE_LIMIT_EVENT_TIME")
-        collector.increment_rejected("SEQUENCE_ERROR")
-        collector.increment_rejected("FUTURE_TIMESTAMP")
-        collector.increment_rejected("STALE_REPLAY")
-        collector.increment_rejected("INACTIVE_TRIP")
-        collector.increment_rejected("TRIP_CACHE_REBUILDING")
+        for reason in REJECTION_REASONS:
+            collector.increment_rejected(reason)
 
         snapshot = collector.get_snapshot()
+        assert snapshot["rejections_by_reason"] == {
+            reason: 1 for reason in REJECTION_REASONS
+        }
         assert snapshot["messages_rejected_json"] == 1
         assert snapshot["messages_rejected_missing_timestamp"] == 1
         assert snapshot["messages_rejected_schema"] == 1
@@ -72,7 +65,7 @@ class TestMetricsCollectorCore:
         assert snapshot["messages_rejected_sequence"] == 1
         assert snapshot["messages_rejected_future_timestamp"] == 1
         assert snapshot["messages_rejected_stale_replay"] == 1
-        assert snapshot["messages_rejected"] == 12
+        assert snapshot["messages_rejected"] == len(REJECTION_REASONS)
 
     def test_unknown_rejection_type_does_not_increment_totals(self):
         collector = MetricsCollector()
@@ -190,6 +183,11 @@ class TestHealthEndpoints:
         client, collector = health_client
         collector.kafka_broker_up = True
         collector.mqtt_broker_up = True
+        collector.update_trip_cache(
+            status="ready",
+            active_trip_count=0,
+            last_lifecycle_timestamp=None,
+        )
         collector.increment_received()
         collector.increment_validated()
 
@@ -200,8 +198,28 @@ class TestHealthEndpoints:
         assert payload["status"] == "healthy"
         assert payload["dependencies"]["kafka_broker"] == "up"
         assert payload["dependencies"]["mqtt_broker"] == "up"
+        assert payload["trip_cache"]["ready"] is True
+        assert payload["trip_cache"]["status"] == "ready"
         assert payload["counters"]["messages_received"] == 1
         assert payload["counters"]["messages_validated"] == 1
+
+    def test_ready_endpoint_returns_503_when_trip_cache_not_ready(self, health_client):
+        client, collector = health_client
+        collector.kafka_broker_up = True
+        collector.mqtt_broker_up = True
+        collector.update_trip_cache(
+            status="rebuilding",
+            active_trip_count=0,
+            last_lifecycle_timestamp=None,
+        )
+
+        response = client.get("/health/ready")
+
+        assert response.status_code == 503
+        payload = response.json()
+        assert payload["status"] == "degraded"
+        assert payload["trip_cache"]["ready"] is False
+        assert payload["trip_cache"]["status"] == "rebuilding"
 
     def test_health_endpoint_returns_summary_payload(self, health_client):
         client, collector = health_client
@@ -219,6 +237,8 @@ class TestHealthEndpoints:
         assert payload["dependencies"]["kafka_broker"] == "up"
         assert payload["dependencies"]["mqtt_broker"] == "down"
         assert payload["dependencies"]["trip_cache"] == "unknown"
+        assert payload["trip_cache"]["ready"] is False
+        assert payload["trip_cache"]["last_lifecycle_event_timestamp"] is None
         assert payload["counters"]["messages_received"] == 1
         assert payload["counters"]["messages_rejected"] == 1
         assert payload["counters"]["heartbeats_received"] == 0
@@ -238,6 +258,11 @@ class TestHealthEndpoints:
         collector.mqtt_broker_up = True
         collector.increment_received()
         collector.increment_validated()
+        collector.update_trip_cache(
+            status="ready",
+            active_trip_count=2,
+            last_lifecycle_timestamp="2026-05-02T10:00:00+00:00",
+        )
         collector.record_heartbeat(bus_id="1", timestamp=datetime.now(timezone.utc))
         collector.increment_rejected("RATE_LIMIT")
 
@@ -251,6 +276,8 @@ class TestHealthEndpoints:
         assert "ingestion_heartbeat_messages_received_total 1" in body
         assert "ingestion_heartbeat_messages_invalid_total 0" in body
         assert 'ingestion_heartbeat_age_seconds{bus_id="1"}' in body
+        for reason in REJECTION_REASONS:
+            assert f'ingestion_messages_rejected_total{{reason="{reason}"}}' in body
         assert 'ingestion_messages_rejected_total{reason="RATE_LIMIT"} 1' in body
         assert 'ingestion_messages_rejected_total{reason="INACTIVE_TRIP"} 0' in body
         assert 'ingestion_messages_rejected_total{reason="TRIP_CACHE_REBUILDING"} 0' in body
@@ -258,6 +285,8 @@ class TestHealthEndpoints:
         assert 'ingestion_messages_rejected_total{reason="FUTURE_TIMESTAMP"} 0' in body
         assert 'ingestion_messages_rejected_total{reason="STALE_REPLAY"} 0' in body
         assert 'ingestion_messages_rejected_total{reason="MISSING_TIMESTAMP"} 0' in body
+        assert "ingestion_trip_cache_ready 1" in body
+        assert "ingestion_trip_cache_active_trips 2" in body
         assert "ingestion_kafka_broker_up 1" in body
         assert "ingestion_mqtt_broker_up 1" in body
 

--- a/services/ingestion/tests/unit/test_producer.py
+++ b/services/ingestion/tests/unit/test_producer.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
@@ -60,6 +61,60 @@ def test_publish_to_dlq(mock_kafka_class):
     assert envelope["error_reason"] == "Invalid JSON"
     assert envelope["error_type"] == "JSON_PARSE"
     assert envelope["source"] == "mqtt"
+    assert envelope["source_topic"] == "transport/bus/BUS_999/location"
+    assert envelope["busId"] == "BUS_999"
+    assert envelope["tripId"] is None
+    assert envelope["event_timestamp"] is None
+    assert envelope["received_at"].endswith("+00:00")
+
+
+@patch("services.ingestion.app.producer.KafkaProducer")
+def test_publish_to_dlq_extracts_parseable_payload_metadata(mock_kafka_class):
+    mock_producer = MagicMock()
+    mock_kafka_class.return_value = mock_producer
+    producer = TelemetryProducer()
+    timestamp = "2026-05-02T10:15:30Z"
+    payload = {
+        "busId": "1",
+        "tripId": "TRIP-001",
+        "lat": 6.9271,
+        "lon": 79.8612,
+        "timestamp": timestamp,
+    }
+
+    producer.publish_to_dlq(
+        raw_payload=json.dumps(payload).encode("utf-8"),
+        error_reason="Duplicate",
+        error_type="DUPLICATE",
+        source_topic="transport/bus/1/location",
+    )
+
+    _, kwargs = mock_producer.send.call_args
+    envelope = kwargs["value"]
+    assert envelope["busId"] == "1"
+    assert envelope["tripId"] == "TRIP-001"
+    assert envelope["event_timestamp"] == "2026-05-02T10:15:30+00:00"
+
+
+@patch("services.ingestion.app.producer.KafkaProducer")
+def test_publish_to_dlq_handles_undecodable_payload(mock_kafka_class):
+    mock_producer = MagicMock()
+    mock_kafka_class.return_value = mock_producer
+    producer = TelemetryProducer()
+
+    producer.publish_to_dlq(
+        raw_payload=b"\xff\xfe",
+        error_reason="Invalid JSON",
+        error_type="JSON_PARSE",
+        source_topic="transport/bus/1/location",
+    )
+
+    _, kwargs = mock_producer.send.call_args
+    envelope = kwargs["value"]
+    assert envelope["busId"] == "1"
+    assert envelope["tripId"] is None
+    assert envelope["event_timestamp"] is None
+    assert envelope["original_payload"]
 
 
 @patch("services.ingestion.app.producer.KafkaProducer")


### PR DESCRIPTION

I kept validator.py untouched, so GPS validation logic did not get mixed up.

Changed:

metrics.py now tracks rejection reasons through a dictionary, while keeping old snapshot keys

health.py now exposes trip cache readiness and Prometheus  trip cache gauges

producer.py  now enriche DLQ messages with safe metadata: busId, tripId, event_timestamp, source topic, reason, received time

Added ests for DLQ metadata, undecodable payloads, rejection metrics, and tripcache readiness

Updated ingestion  README
