### PR TITLE
docs: Plan — Off-Route Detection, Persistent Anomaly, eta_db, SARIMA Forecasting

### DIFF
--- a/docs/CR_1.md
+++ b/docs/CR_1.md
@@ -65,7 +65,7 @@ graph TD
     RedisETA -->|Subscribes| Kong
     RedisAnomaly -->|Subscribes| Kong
     
-    Kong -->|WebSockets| Dashboard["Live Dashboards"]:::g1
+    Kong -->|WebSockets| Dashboard["G3 Frontend"]:::g1
 ```
 
 ---

--- a/docs/CR_1.md
+++ b/docs/CR_1.md
@@ -65,7 +65,7 @@ graph TD
     RedisETA -->|Subscribes| Kong
     RedisAnomaly -->|Subscribes| Kong
     
-    Kong -->|WebSockets| Dashboard["G3 Frontend"]:::g1
+    Kong -->|WebSockets/REST APIs| Dashboard["G3 Frontend"]:::g1
 ```
 
 ---

--- a/docs/CR_1.md
+++ b/docs/CR_1.md
@@ -27,41 +27,41 @@ graph TD
     classDef ws fill:#e1d5e7,stroke:#9673a6,stroke-width:2px;
     classDef db fill:#b1ddf0,stroke:#10739e,stroke-width:2px;
 
-    G1["G1 IoT Device"]:::g1 -->|MQTT Protocol| Broker["G4 MQTT Broker<br>(Rate Limits per connection)"]:::mqtt
+    G1["G1 IoT Device"]:::g1 -->|MQTT Stream| Broker["G4 MQTT Broker<br>(Rate Limits)"]:::mqtt
     
-    Broker -->|Subscribe| Ingest["Ingestion Service<br>Ultra-Dumb Pipe"]:::ingest
-    Ingest -->|Schema Failures| DLQ["telemetry-dlq"]:::kafka
-    Ingest -->|Passes JSON Parse| Raw["transport-telemetry-raw"]:::kafka
+    Broker -->|Subscribe| Ingest["Ingestion Service<br>(Dumb Pipe)"]:::ingest
+    Ingest -->|Invalid Schema| DLQ[("Kafka Topic<br>telemetry-dlq")]:::kafka
+    Ingest -->|Valid JSON| Raw[("Kafka Topic<br>transport-telemetry-raw")]:::kafka
     
-    FleetService["Fleet Management Service"]:::service -->|Start/Stop Trip| Lifecycle["trip.lifecycle"]:::kafka
-    RouteService["Route Service"]:::service -.->|REST API Startup Cache| Flink
-    FleetService -.->|REST API Startup Cache| Flink
+    FleetService["Fleet Management Service"]:::service -->|Trip Events| Lifecycle[("Kafka Topic<br>trip.lifecycle")]:::kafka
+    RouteService["Route Service"]:::service -.->|Startup Cache| Flink
+    FleetService -.->|Startup Cache| Flink
     
     Raw --> Flink["Apache Flink<br>(The Source of Truth)"]:::flink
     Lifecycle --> Flink
     
-    Flink -->|Impossible Physics| Invalid["telemetry-invalid<br>(Logs/Observability)"]:::kafka
-    Flink -->|Historical Data| InfluxDB[("InfluxDB<br>(ML Training Data)")]:::db
-    Flink -->|Live Map Fast-Path| RedisLive[("Redis KV / PubSub<br>(fleet:live)")]:::redis
-    Flink -->|Enriched Data| Cleaned["transport-telemetry-cleaned"]:::kafka
+    Flink -->|Physics Violated| Invalid[("Kafka Topic<br>telemetry-invalid")]:::kafka
+    Flink -->|History Sink| InfluxDB[("InfluxDB<br>(ML Training)")]:::db
+    Flink -->|Live Map| RedisLive[("Redis PubSub<br>(fleet:live)")]:::redis
+    Flink -->|Enriched JSON| Cleaned[("Kafka Topic<br>transport-telemetry-cleaned")]:::kafka
     
     Cleaned --> ETA["ETA Service<br>(SARIMA Inference)"]:::service
-    Cleaned --> Anomaly["Anomaly Service<br>(In-Memory Rolling Window<br>+ Isolation Forest)"]:::service
+    Cleaned --> Anomaly["Anomaly Service<br>(Rolling Window + Isolation Forest)"]:::service
     
-    InfluxDB -.->|Offline Training Data| ETA
-    InfluxDB -.->|Offline Training Data| Anomaly
+    InfluxDB -.->|Offline Models| ETA
+    InfluxDB -.->|Offline Models| Anomaly
     
     DLQ --> Elastic[("Elasticsearch<br>(Log Aggregation)")]:::db
     Invalid --> Elastic
     
     ETA -->|Predictions| RedisETA[("Redis PubSub<br>(eta:live)")]:::redis
-    ETA -->|Persistent Records| ETADb[("PostgreSQL<br>(eta_db)")]:::db
+    ETA -->|Persistent| ETADb[("PostgreSQL<br>(eta_db)")]:::db
     
     Anomaly -->|Live Alerts| RedisAnomaly[("Redis PubSub<br>(anomaly:live)")]:::redis
-    Anomaly -->|Historical Alerts| AnomalyDb[("PostgreSQL<br>(anomaly_db)")]:::db
+    Anomaly -->|Persistent| AnomalyDb[("PostgreSQL<br>(anomaly_db)")]:::db
     
-    %% Direct to Kong API Gateway Bypass
-    RedisLive -->|Subscribes| Kong["G4 Kong API Gateway<br>(WebSocket Routing)"]:::ws
+    %% Kong API Gateway Bypass
+    RedisLive -->|Subscribes| Kong["G4 Kong API Gateway"]:::ws
     RedisETA -->|Subscribes| Kong
     RedisAnomaly -->|Subscribes| Kong
     

--- a/docs/CR_1.md
+++ b/docs/CR_1.md
@@ -46,18 +46,24 @@ graph TD
     Flink -->|Enriched Data| Cleaned["transport-telemetry-cleaned"]:::kafka
     
     Cleaned --> ETA["ETA Service<br>(SARIMA Inference)"]:::service
-    Cleaned --> Anomaly["Anomaly Service<br>(Isolation Forest / Rules)"]:::service
+    Cleaned --> Anomaly["Anomaly Service<br>(In-Memory Rolling Window<br>+ Isolation Forest)"]:::service
+    
+    InfluxDB -.->|Offline Training Data| ETA
+    InfluxDB -.->|Offline Training Data| Anomaly
     
     DLQ --> Elastic[("Elasticsearch<br>(Log Aggregation)")]:::db
     Invalid --> Elastic
     
     ETA -->|Predictions| RedisETA[("Redis PubSub<br>(eta:live)")]:::redis
-    Anomaly -->|Alerts| Alerts["transport-anomaly-alerts"]:::kafka
+    ETA -->|Persistent Records| ETADb[("PostgreSQL<br>(eta_db)")]:::db
     
-    %% Direct to Kong Bypass as per Chamodh
-    RedisLive -->|Direct PubSub| Kong["G4 Kong API Gateway<br>(WebSocket Server)"]:::ws
-    RedisETA -->|Direct PubSub| Kong
-    Alerts -->|Kafka Plugin?| Kong
+    Anomaly -->|Live Alerts| RedisAnomaly[("Redis PubSub<br>(anomaly:live)")]:::redis
+    Anomaly -->|Historical Alerts| AnomalyDb[("PostgreSQL<br>(anomaly_db)")]:::db
+    
+    %% Direct to Kong API Gateway Bypass
+    RedisLive -->|Subscribes| Kong["G4 Kong API Gateway<br>(WebSocket Routing)"]:::ws
+    RedisETA -->|Subscribes| Kong
+    RedisAnomaly -->|Subscribes| Kong
     
     Kong -->|WebSockets| Dashboard["Live Dashboards"]:::g1
 ```
@@ -76,6 +82,20 @@ A fundamental shift in this architecture is how we handle "bad" behavior.
 3. **Anomaly Service's Job:** Sees `on_route = false` and immediately fires a "Route Deviation Anomaly" alert to the WebSockets.
 
 This prevents silent data loss and ensures our ML and anomaly models have full visibility into unauthorized bus movements.
+
+### 3.1 Anomaly Service: Feature Extraction for Unsupervised ML
+
+The Anomaly Service uses an **Isolation Forest** to detect erratic driving patterns. Because an Isolation Forest does not natively understand "time" (it expects a single feature vector like `[X, Y, Z]`), we cannot simply feed it raw coordinates and timestamps from a sliding window of GPS pings.
+
+**The Feature Extraction Workflow:**
+1. **Sliding Window:** The service maintains a sliding window of the last 10-20 GPS pings.
+2. **Summary Vector:** When a new ping arrives, it calculates a summary vector representing the behavior within that window. Example metrics include:
+   - `max_acceleration`: Did they floor the gas pedal?
+   - `min_acceleration`: Did they slam on the brakes?
+   - `speed_variance`: Is their speed fluctuating wildly?
+   - `heading_variance`: Are they swerving?
+3. **Inference:** Instead of feeding raw pings, the service feeds this single summary vector (e.g., `[4.2, -5.1, 12.5, 45.0]`) into the Isolation Forest.
+4. **Detection:** The model, which was trained offline on millions of normal 10-second summary vectors, evaluates if the current vector looks "normal". If the driver is slamming the brakes and swerving, the vector lands far outside the normal cluster, the model outputs `-1`, and an `ERRATIC_DRIVING` alert is instantly fired.
 
 ---
 

--- a/docs/ETA_OFFROUTE_ANOMALY_SARIMA_PLAN.md
+++ b/docs/ETA_OFFROUTE_ANOMALY_SARIMA_PLAN.md
@@ -113,8 +113,8 @@ and ignore unknown fields — no breaking change.
 
 | File | Change |
 |------|--------|
-| `services/anomaly-service/app/models/anomaly_model.py` | `off_route_streak` dict + streak logic |
-| `services/anomaly-service/app/main.py` | `persistent_off_route_threshold: int = 3` setting |
+| `services/anomaly-service/app/models/anomaly_model.py` | `off_route_streak_start_time` dict + time window logic |
+| `services/anomaly-service/app/config.py` | `OFF_ROUTE_STREAK_WINDOW_SEC: int = 5` loaded as Env Var |
 | `services/anomaly-service/tests/` | Streak unit tests |
 
 ### Logic
@@ -123,20 +123,22 @@ and ignore unknown fields — no breaking change.
 detect(telemetry, geometry):
   # use precomputed flag if Flink provides it; else compute locally (backward-compat)
   is_off = telemetry.get("offRoute") ?? (distance_to_polyline(...) > 50)
+  current_time = telemetry.get("timestamp")
 
   if is_off:
-    streak[bus_id] += 1
-    if streak[bus_id] == 1:
+    if bus_id not in streak_start:
+      streak_start[bus_id] = current_time
       emit OFF_ROUTE alert         # existing single-hit alert (unchanged)
-    if streak[bus_id] >= threshold:
+    
+    elapsed = current_time - streak_start[bus_id]
+    if elapsed >= OFF_ROUTE_STREAK_WINDOW_SEC:
       emit PERSISTENT_OFF_ROUTE alert
   else:
-    streak[bus_id] = 0             # reset on any on-route reading
+    streak_start.pop(bus_id, None) # reset on any on-route reading
 ```
 
-**Why threshold = 3?**  
-GPS fixes arrive ~1/s. Three consecutive off-route readings = ≥3 s continuously outside the
-50 m corridor. GPS noise does not persist for 3 consecutive fixes at this frequency.
+**Why a 5-second time window?**  
+A fixed time window is more robust than a strict count of pings (which assumes a perfect 1Hz frequency). 5 seconds of continuous off-route readings guarantees the bus genuinely deviated and avoids firing on fleeting GPS noise. Constant is stored in `app/config.py`.
 
 ### New alert type
 
@@ -191,9 +193,11 @@ ETA_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-p
 
 ### `eta_records` table schema
 
+To efficiently manage high-frequency telemetry storage without heavy cron `DELETE` jobs, the table uses PostgreSQL partitioning by month. This is defined via a lightweight Alembic setup specifically inside `services/eta-service/`.
+
 ```sql
 CREATE TABLE eta_records (
-  id            SERIAL PRIMARY KEY,
+  id            SERIAL,
   trip_id       TEXT        NOT NULL,
   bus_id        TEXT        NOT NULL,
   route_id      TEXT,
@@ -205,8 +209,13 @@ CREATE TABLE eta_records (
   clamped       BOOLEAN     NOT NULL DEFAULT false,
   off_route     BOOLEAN     NOT NULL DEFAULT false,
   timestamp     TIMESTAMPTZ NOT NULL,  -- from GPS message
-  recorded_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
+  recorded_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (id, timestamp)
+) PARTITION BY RANGE (timestamp);
+
+-- Example partition creation (managed by automation/Alembic)
+CREATE TABLE eta_records_y2026m05 PARTITION OF eta_records 
+    FOR VALUES FROM ('2026-05-01') TO ('2026-06-01');
 
 CREATE INDEX eta_records_route_stop_idx ON eta_records (route_id, stop_id, timestamp);
 CREATE INDEX eta_records_trip_idx       ON eta_records (trip_id, timestamp);
@@ -267,6 +276,8 @@ therefore better suited when the input is a temporal sequence rather than a feat
 
 ### `train_sarima.py` workflow
 
+All constants like minimum training threshold are loaded as environment variables via `app/config.py` (e.g., `SARIMA_MIN_THRESHOLD_HOURS=48`). We keep the 48-hour requirement to ensure 2 full seasonal cycles and avoid skew from single-day anomalies like public holidays.
+
 ```
 1. SELECT trip_id, stop_id, route_id, eta_seconds, timestamp
    FROM eta_records
@@ -275,7 +286,7 @@ therefore better suited when the input is a temporal sequence rather than a feat
 
 2. Group by (route_id, stop_id)
 
-3. For each group with ≥ 48 samples (2 full seasonal cycles of S=24):
+3. For each group with ≥ 48 hours of data (SARIMA_MIN_THRESHOLD_HOURS):
    a. Resample to hourly mean ETA
    b. Fit SARIMA(1,1,1)(1,1,1,24)
    c. Save: sarima_artifacts/{route_id}_{stop_id}.joblib
@@ -349,18 +360,10 @@ Response 200 (no artifact — graceful fallback):
 
 ---
 
-## Open Questions for Review
+## Resolved Questions (from CR1 Review)
 
-1. **`eta_records` retention policy** — With 1 GPS fix/s per bus across many trips, the table grows
-   quickly. Should we add `DELETE WHERE recorded_at < NOW() - INTERVAL '90 days'` as a cron job,
-   or rely on Postgres partitioning by month? Preference?
-
-2. **SARIMA minimum sample threshold (48)** — Is 48 h of data (2 seasonal cycles) a reasonable
-   minimum before the model activates, or should it be lower (e.g., 24 h for one cycle)?
-
-3. **Off-route streak threshold (3)** — GPS fixes arrive ~1 s apart in our simulator. Should the
-   threshold be a count (3 readings) or a time window (e.g., 5 s of consecutive off-route)?
-
-4. **`eta_db` schema ownership** — Using `create_all()` at startup is simple but means rollbacks
-   require manual `DROP TABLE`. Should we add a lightweight Alembic setup inside
-   `services/eta-service/` instead (consistent with how route-service uses the root Alembic)?
+1. **`eta_records` retention policy**: We will use **Postgres table partitioning by month**. This is vastly more efficient for high-frequency telemetry than a cron `DELETE` job.
+2. **SARIMA minimum sample threshold**: Kept at **48 hours (2 cycles)** to avoid skewed models from single-day anomalies (e.g., public holidays). Configured via Env Var.
+3. **Off-route streak threshold**: A **time-based 5-second sliding window** is used instead of a fixed ping count. Configured via Env Var.
+4. **`eta_db` schema ownership**: Will use a **lightweight Alembic** configuration placed directly inside `services/eta-service/`.
+5. **Hardcoded Numbers**: All constants (thresholds, windows, retention logic) must be moved to `app/config.py` and loaded dynamically via Environment Variables.

--- a/docs/ETA_OFFROUTE_ANOMALY_SARIMA_PLAN.md
+++ b/docs/ETA_OFFROUTE_ANOMALY_SARIMA_PLAN.md
@@ -1,0 +1,366 @@
+# Plan: Off-Route Detection · Persistent Anomaly · ETA Persistence · SARIMA Forecasting
+
+**Authors:** Kusal (Lead)  
+**Status:** Awaiting Approval (Chamodh, Janidu)  
+**Relates to:** ETA pipeline (`ETA` branch, PR #92), Inc 2
+
+---
+
+## Problem Statement
+
+The existing `gps-cleaned` Kafka topic feeds the ETA Service directly from the Flink
+EnrichmentFunction. However:
+
+1. **Flink already detects off-route positions** (via route geometry projection) but discards
+   the deviation distance — it does not emit a flag the ETA Service can use.
+2. **A single off-route fix may be GPS noise.** Only a sustained off-route streak (3+
+   consecutive readings) indicates the bus genuinely deviated and ETA should be suppressed.
+3. **All computed ETA values are currently ephemeral** (Redis TTL 300 s). There is no
+   persistent record for retrospective analysis or future ML training.
+4. **SARIMA time-series forecasting** is a natural next step once per-stop ETA history
+   accumulates — it models the repeating hour-of-day / day-of-week seasonality that XGBoost
+   cannot capture without careful feature engineering.
+
+---
+
+## Architecture Overview
+
+```
+Flink EnrichmentFunction
+  ├── already computes projection min-distance internally
+  └── NEW: expose it as offRoute (bool) + offRouteDistanceM (float) on every enriched message
+        ↓
+  transport-telemetry-cleaned  (existing consumers unaffected — additive field)
+  gps-cleaned                  (ETA Service consumer)
+        ↓
+  ┌──────────────────────────────────────────────────┐
+  │  Anomaly Service                                 │
+  │  existing: single-hit OFF_ROUTE alert            │
+  │  NEW:      off_route_streak counter per bus      │
+  │            ≥ 3 consecutive → PERSISTENT_OFF_ROUTE│
+  └──────────────────────────────────────────────────┘
+        ↓
+  ┌──────────────────────────────────────────────────┐
+  │  ETA Service consumer                            │
+  │  NEW guard: if offRoute → skip Redis + eta:live  │
+  │  NEW persist: every valid ETA → eta_db           │
+  └──────────────────────────────────────────────────┘
+        ↓
+  eta_db (PostgreSQL, separate logical DB)
+        ↓
+  train_sarima.py (offline CLI)
+        ↓
+  sarima_eta.py (GET /api/v1/eta/{tripId}/{stopId}?model=sarima)
+```
+
+---
+
+## Database Isolation
+
+| Database   | Service                        | Why separate                          |
+|------------|--------------------------------|---------------------------------------|
+| `ontime_db`| route-service, api-gateway     | Route/stop geometry, bus master data  |
+| `fleet_db` | fleet-management-service       | Trip lifecycle, driver assignments    |
+| `eta_db`   | **eta-service only** ← NEW     | ETA records, SARIMA training data     |
+
+`eta_db` is a separate **logical database** on the same `ontime_postgres` container — identical
+pattern already used by `fleet_db`. No PostGIS extension needed. Schema created by SQLAlchemy
+`create_all()` at service startup; no root-level Alembic required.
+
+---
+
+## Phase 1 — `offRoute` field in Flink
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `services/stream-processing/app/utils/geo.py` | Add `distance_to_route(lat, lon, points) → float` |
+| `services/stream-processing/app/transforms/enrichment.py` | Emit `offRoute` + `offRouteDistanceM` |
+| `services/stream-processing/tests/unit/test_enrichment.py` | 2 new tests |
+
+### `distance_to_route()`
+
+Reuses the projection loop already inside `calculate_route_progress` — extracts and returns the
+`min_dist` that is currently computed but thrown away. Zero overhead: the geometry is already
+iterated on every message.
+
+### Enriched message additions
+
+```json
+{
+  "offRoute": true,
+  "offRouteDistanceM": 83.4
+}
+```
+
+- `offRoute: true` when projection distance > **50 m** (same threshold already used by the
+  Anomaly Service `OFF_ROUTE` check — consistency).
+- When `routeId` is `null` (bus not on a trip): `offRoute: false`, `offRouteDistanceM: 0.0`.
+- **Both** `transport-telemetry-cleaned` and `gps-cleaned` carry these fields automatically
+  because both sinks consume the same `processed_ds` — no extra sink code needed.
+
+### Backward compatibility
+
+Existing consumers of `transport-telemetry-cleaned` (Anomaly Service, InfluxDB sink) parse JSON
+and ignore unknown fields — no breaking change.
+
+---
+
+## Phase 2 — Anomaly Service: `PERSISTENT_OFF_ROUTE` streak
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `services/anomaly-service/app/models/anomaly_model.py` | `off_route_streak` dict + streak logic |
+| `services/anomaly-service/app/main.py` | `persistent_off_route_threshold: int = 3` setting |
+| `services/anomaly-service/tests/` | Streak unit tests |
+
+### Logic
+
+```
+detect(telemetry, geometry):
+  # use precomputed flag if Flink provides it; else compute locally (backward-compat)
+  is_off = telemetry.get("offRoute") ?? (distance_to_polyline(...) > 50)
+
+  if is_off:
+    streak[bus_id] += 1
+    if streak[bus_id] == 1:
+      emit OFF_ROUTE alert         # existing single-hit alert (unchanged)
+    if streak[bus_id] >= threshold:
+      emit PERSISTENT_OFF_ROUTE alert
+  else:
+    streak[bus_id] = 0             # reset on any on-route reading
+```
+
+**Why threshold = 3?**  
+GPS fixes arrive ~1/s. Three consecutive off-route readings = ≥3 s continuously outside the
+50 m corridor. GPS noise does not persist for 3 consecutive fixes at this frequency.
+
+### New alert type
+
+```json
+{
+  "anomalyType": "PERSISTENT_OFF_ROUTE",
+  "message": "Bus off-route for 3 consecutive readings (≥150 m deviation streak)",
+  "busId": "BUS-007",
+  "tripId": "TRIP-2026-001",
+  "routeId": "1",
+  "streakCount": 3
+}
+```
+
+---
+
+## Phase 3 — Infrastructure: `eta_db`
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `docker/init/01-databases.sql` | Add `CREATE DATABASE eta_db;` |
+| `docker/docker-compose.yml` | Add `ETA_DATABASE_URL` env to `eta-service` block |
+| `docker/docker-compose.yml` `kafka-init` | Add `gps-cleaned` Kafka topic (currently missing from init) |
+
+### `docker/init/01-databases.sql` addition
+
+```sql
+CREATE DATABASE eta_db;
+```
+
+### `docker-compose.yml` eta-service env addition
+
+```yaml
+ETA_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/eta_db
+```
+
+---
+
+## Phase 4 — ETA Service: off-route guard + persistence
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `services/eta-service/models/eta_record.py` | NEW — SQLAlchemy ORM model |
+| `services/eta-service/models/eta_db.py` | NEW — engine + `init_db()` + `get_session()` |
+| `services/eta-service/consumer.py` | Off-route guard + DB insert after Redis write |
+| `services/eta-service/main.py` | Call `init_db()` in FastAPI lifespan |
+| `services/eta-service/requirements.txt` | Add `psycopg2-binary`, `sqlalchemy>=2.0` |
+
+### `eta_records` table schema
+
+```sql
+CREATE TABLE eta_records (
+  id            SERIAL PRIMARY KEY,
+  trip_id       TEXT        NOT NULL,
+  bus_id        TEXT        NOT NULL,
+  route_id      TEXT,
+  stop_id       INTEGER,
+  eta_seconds   FLOAT       NOT NULL,
+  distance_m    FLOAT       NOT NULL,
+  speed_ms      FLOAT       NOT NULL,
+  model_used    TEXT        NOT NULL,  -- 'physics' | 'xgboost' | 'sarima'
+  clamped       BOOLEAN     NOT NULL DEFAULT false,
+  off_route     BOOLEAN     NOT NULL DEFAULT false,
+  timestamp     TIMESTAMPTZ NOT NULL,  -- from GPS message
+  recorded_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX eta_records_route_stop_idx ON eta_records (route_id, stop_id, timestamp);
+CREATE INDEX eta_records_trip_idx       ON eta_records (trip_id, timestamp);
+```
+
+### Off-route guard in `consumer.py`
+
+```python
+if payload.get("offRoute"):
+    logger.warning(
+        "Skipping ETA for off-route bus %s (trip %s, deviation %.1f m)",
+        payload.get("busId"), payload.get("tripId"),
+        payload.get("offRouteDistanceM", 0.0),
+    )
+    return {"skipped": True, "reason": "off_route"}
+```
+
+- No Redis snapshot update.
+- No `eta:live` publish.
+- No `eta_records` insert.
+- Downstream: WebSocket clients see no update (stale ETA retained until TTL 300 s or trip ends).
+
+### DB insert (non-blocking)
+
+```python
+try:
+    eta_db.insert_record(snapshot, stop_id=event.next_stop_id, off_route=False)
+except Exception as exc:
+    logger.error("eta_db insert failed (non-fatal): %s", exc)
+    # Real-time path continues regardless
+```
+
+---
+
+## Phase 5 — SARIMA Time-Series ETA Forecasting
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `services/eta-service/models/training/train_sarima.py` | NEW — offline CLI training script |
+| `services/eta-service/models/sarima_eta.py` | NEW — forecast function |
+| `services/eta-service/routers/eta.py` | Add `?model=sarima` branch |
+| `services/eta-service/requirements.txt` | Add `statsmodels>=0.14` |
+| `services/eta-service/tests/unit/test_sarima_eta.py` | NEW — unit tests |
+
+### Why SARIMA?
+
+`eta_records` for a given `(route_id, stop_id)` pair forms a time series of observed ETA values
+indexed by `timestamp`. Bus dwell patterns exhibit:
+
+- **Daily seasonality (S=24)**: rush-hour spikes at 7–9 am and 5–7 pm every weekday.
+- **Weekly seasonality**: weekends have lower and more uniform ETAs.
+
+SARIMA `(p=1, d=1, q=1)(P=1, D=1, Q=1, S=24)` captures both. XGBoost handles these via
+engineered features; SARIMA captures them directly from the history of observations and is
+therefore better suited when the input is a temporal sequence rather than a feature vector.
+
+### `train_sarima.py` workflow
+
+```
+1. SELECT trip_id, stop_id, route_id, eta_seconds, timestamp
+   FROM eta_records
+   WHERE off_route = false
+   ORDER BY timestamp
+
+2. Group by (route_id, stop_id)
+
+3. For each group with ≥ 48 samples (2 full seasonal cycles of S=24):
+   a. Resample to hourly mean ETA
+   b. Fit SARIMA(1,1,1)(1,1,1,24)
+   c. Save: sarima_artifacts/{route_id}_{stop_id}.joblib
+   d. Print AIC, RMSE on hold-out last 24 h
+
+4. Exit 0 on success; exit 1 if any group fails to converge
+```
+
+### `sarima_eta.forecast_eta_sarima(route_id, stop_id, dt)`
+
+```python
+@lru_cache(maxsize=128)
+def _load_artifact(route_id, stop_id): ...   # loads joblib, None if missing
+
+def forecast_eta_sarima(route_id, stop_id, dt=None) -> float | None:
+    model = _load_artifact(route_id, stop_id)
+    if model is None:
+        return None    # caller falls back to XGBoost / physics
+    dt = dt or datetime.now()
+    forecast = model.predict(start=dt, end=dt)
+    return float(max(0.0, forecast.iloc[0]))
+```
+
+### HTTP endpoint addition
+
+```
+GET /api/v1/eta/{tripId}/{stopId}?model=sarima
+
+Response 200 (artifact available):
+  { "model_used": "sarima", "eta_seconds": 118.3, ... }
+
+Response 200 (no artifact — graceful fallback):
+  { "model_used": "physics", "eta_seconds": 120.5, ... }
+```
+
+---
+
+## Verification Checklist
+
+### Infrastructure
+- [ ] `docker exec ontime_postgres psql -U postgres -c "\l"` → `eta_db` listed
+- [ ] `docker exec ontime_postgres psql -U postgres -d eta_db -c "\dt"` → `eta_records` table exists
+
+### Phase 1 — `offRoute` field
+- [ ] `pytest services/stream-processing/tests/unit/test_enrichment.py -v` → all pass (incl. `offRoute` tests)
+- [ ] Enriched message on `gps-cleaned` contains `offRoute`, `offRouteDistanceM`
+
+### Phase 2 — Anomaly streak
+- [ ] `pytest services/anomaly-service/tests/ -v` → streak tests pass
+- [ ] Run GPS simulator with bus off-route for 3+ readings → `transport-anomaly-alerts` contains `PERSISTENT_OFF_ROUTE`
+
+### Phase 4 — ETA persistence
+- [ ] `pytest services/eta-service/tests/ -v` → all pass + new guard/persist tests
+- [ ] On-route message → `eta_records` row inserted
+- [ ] Off-route message → no row in `eta_records`, no `eta:live` publish
+
+### Phase 5 — SARIMA
+- [ ] `pytest services/eta-service/tests/unit/test_sarima_eta.py -v`
+- [ ] `python3 services/eta-service/models/training/train_sarima.py` → artifacts in `sarima_artifacts/`
+- [ ] `GET /api/v1/eta/TRIP-001/42?model=sarima` → `model_used: sarima` or graceful fallback
+
+---
+
+## Scope Boundaries
+
+- `transport-telemetry-cleaned` consumers (Anomaly Service, InfluxDB) are **not broken** — `offRoute` is additive.
+- WebSocket Service requires **no changes** — it subscribes to `eta:live` unchanged.
+- SARIMA training is **offline/manual** — `train_sarima.py` is a CLI script, not a background task.
+- The XGBoost pipeline (K-7–K-10, PR #92) is **not replaced** — SARIMA is an additional `?model=sarima` option.
+- `eta_db` is on the same Postgres container; no new Docker service needed.
+
+---
+
+## Open Questions for Review
+
+1. **`eta_records` retention policy** — With 1 GPS fix/s per bus across many trips, the table grows
+   quickly. Should we add `DELETE WHERE recorded_at < NOW() - INTERVAL '90 days'` as a cron job,
+   or rely on Postgres partitioning by month? Preference?
+
+2. **SARIMA minimum sample threshold (48)** — Is 48 h of data (2 seasonal cycles) a reasonable
+   minimum before the model activates, or should it be lower (e.g., 24 h for one cycle)?
+
+3. **Off-route streak threshold (3)** — GPS fixes arrive ~1 s apart in our simulator. Should the
+   threshold be a count (3 readings) or a time window (e.g., 5 s of consecutive off-route)?
+
+4. **`eta_db` schema ownership** — Using `create_all()` at startup is simple but means rollbacks
+   require manual `DROP TABLE`. Should we add a lightweight Alembic setup inside
+   `services/eta-service/` instead (consistent with how route-service uses the root Alembic)?

--- a/docs/INCREMENT_2_PLAN_1.md
+++ b/docs/INCREMENT_2_PLAN_1.md
@@ -126,26 +126,34 @@ graph TD
     AnomalyML["Anomaly Service Models<br>(Natasha)"]:::natasha
     
     DBs["Fleet & Route Services / DBs<br>(Chamodh)"]:::chamodh
-    AnomalyDB["Anomaly DB Integration<br>(Chamodh)"]:::chamodh
+    PostgresDBs["ETA & Anomaly DBs (PostgreSQL)<br>(Chamodh)"]:::chamodh
+    InfluxDB[("InfluxDB<br>(Offline Training)")]:::natasha
     
     ETA["ETA Service Inference<br>(Kusal)"]:::kusal
     
-    RedisBypass["Flink to Redis Fast-Path<br>(Nidharshan)"]:::nidharshan
-    Gateway["API Gateway & WebSockets<br>(Nidharshan)"]:::nidharshan
+    Redis["Redis PubSub<br>(fleet, eta, anomaly)<br>(Nidharshan)"]:::nidharshan
+    WSService["WebSocket Service<br>(Nidharshan)"]:::nidharshan
+    Kong["G4 Kong Gateway<br>(Routing Bypass)"]:::nidharshan
 
     Ingestion --> FlinkCore
     FlinkCore --> FlinkEnrich
     DBs -.-> FlinkEnrich
     
     FlinkEnrich --> AnomalyML
-    AnomalyML --> AnomalyDB
+    AnomalyML --> PostgresDBs
     
     FlinkEnrich --> ETA
+    ETA --> PostgresDBs
     
-    FlinkEnrich --> RedisBypass
-    RedisBypass --> Gateway
-    ETA --> Gateway
-    AnomalyML --> Gateway
+    InfluxDB -.->|Offline Training| ETA
+    InfluxDB -.->|Offline Training| AnomalyML
+    
+    FlinkEnrich --> Redis
+    ETA --> Redis
+    AnomalyML --> Redis
+    
+    Redis --> WSService
+    WSService --> Kong
 ```
 
 ---
@@ -209,9 +217,10 @@ To ensure zero overlap and 100% project completion (including all tests and ML m
   - Create a Kafka consumer for `transport-telemetry-cleaned`.
   - Implement rule-based checks: Trigger instant alerts if `trip_status == INACTIVE` but speed > 0, or if `on_route == false`.
 - **Phase N3 — Isolation Forest ML Model:**
-  - Train an **Isolation Forest** offline using `scikit-learn` on InfluxDB data to detect erratic driving patterns (e.g., unusual acceleration/deceleration sequences on a valid route).
-  - Maintain a sliding window of the last 10 pings per bus in the Anomaly Service memory.
-  - Feed the sliding window into the Isolation Forest model. If anomalous, publish to `transport-anomaly-alerts` (Kafka).
+  - Train an **Isolation Forest** offline using `scikit-learn` on InfluxDB data. **Feature Extraction:** Extract summary vectors (e.g., `max_acceleration`, `min_acceleration`, `speed_variance`, `heading_variance`) from millions of normal 10-second windows to map out "normal" driving behavior.
+  - Maintain a sliding window of the last N pings per bus in the Anomaly Service memory (N loaded from `app/config.py`).
+  - **Real-Time Inference:** Every time a new ping arrives, calculate the summary vector for the current window and feed this vector into the Isolation Forest model.
+  - If anomalous (model outputs `-1`, e.g., driver slamming brakes and swerving lands outside normal cluster), immediately fire an `ERRATIC_DRIVING` alert and publish to `transport-anomaly-alerts` (Kafka).
 - **Phase N4 — Testing & Tuning:**
   - Tune the Isolation Forest contamination parameter to avoid false positives.
   - Write unit tests proving off-route events trigger rules, and erratic speeds trigger the ML model.
@@ -233,22 +242,22 @@ To ensure zero overlap and 100% project completion (including all tests and ML m
 - **Phase C4 — Observability DBs:**
   - Configure the Log sink (Telegraf or simple Python script) to dump `telemetry-dlq` and `telemetry-invalid` into an Elasticsearch container (or Postgres JSONB table) for debugging.
 
-### 3.5 Nidharshan — Flink-to-Redis, WebSockets & API Gateway
-**Goal:** Build the zero-latency delivery mechanism for the passenger and admin dashboards.
+### 3.5 Nidharshan — Flink-to-Redis, WebSockets & Kong Gateway Routing
+**Goal:** Build the zero-latency delivery mechanism for the passenger dashboards while completely bypassing a custom API gateway.
 
 - **Phase Nd1 — Flink-to-Redis Bypass:**
   - Work inside PyFlink to create a Redis Sink.
   - For every cleaned ping, overwrite the Redis Key `bus:{busId}:position` (so we always have the latest state).
   - Simultaneously publish the payload to the Redis PubSub channel `fleet:live`.
-- **Phase Nd2 — WebSocket Kong Configuration (G2 Gateway Bypass):**
-  - If Chamodh confirmed the G2 API Gateway is bypassed for live feeds, work with G4 to configure the **Kong API Gateway** to act as the WebSocket server.
-  - Write the necessary Kong Lua plugins (or use existing Redis plugins) so Kong directly subscribes to Redis PubSub (`fleet:live`, `eta:live`) and pushes to connected WebSockets.
-  - *Note:* If Kong cannot natively subscribe to Redis PubSub, fallback to building the WebSocket endpoint in the G2 API Gateway.
-- **Phase Nd3 — REST API Aggregation:**
-  - Build standard GET endpoints in the API Gateway to proxy requests to Kusal's ETA service (for initial ETA load) and Chamodh's Fleet service (for bus lists).
-  - Implement CORS and ensure headers passed from G4 Kong are handled securely.
+- **Phase Nd2 — Dedicated WebSocket Service:**
+  - Build a lightweight `services/websocket-service/` using FastAPI or Socket.io.
+  - This service strictly subscribes to the three Redis PubSub channels (`fleet:live`, `eta:live`, `anomaly:live`) and pushes those JSON payloads to connected WebSocket clients.
+- **Phase Nd3 — Kong Gateway Routing (API Gateway Bypass):**
+  - **Neglect the G2 custom API Gateway.** Because Kong is incredibly capable, it will handle all our HTTP and WS routing.
+  - Configure Kong routes to forward `/ws` traffic to the new `websocket-service`.
+  - Configure Kong to proxy REST traffic directly to the individual microservices (e.g., `/api/eta` -> `eta-service`, `/api/fleet` -> `fleet-service`).
 - **Phase Nd4 — Load Testing:**
-  - Write a script to simulate 500+ WebSocket clients connecting to the API Gateway simultaneously. Ensure the Gateway does not crash and Redis handles the PubSub fan-out seamlessly.
+  - Write a script to simulate 500+ WebSocket clients connecting through Kong to the WebSocket service simultaneously. Ensure Redis handles the PubSub fan-out seamlessly.
 
 ---
 
@@ -260,5 +269,6 @@ To officially "finish off our thing" and deliver the complete Increment:
 - [ ] SARIMA model successfully predicting ETAs in real-time.
 - [ ] Isolation Forest model successfully catching erratic behavioral anomalies.
 - [ ] Flink correctly executing the "Classify, Don't Drop" logic (Source of Truth).
-- [ ] API Gateway smoothly streaming 3 separate PubSub channels over one WebSocket connection.
+- [ ] WebSocket Service smoothly streaming 3 separate PubSub channels over one connection.
+- [ ] Kong Gateway correctly routing traffic, completely replacing the custom G2 API Gateway.
 - [ ] 100% pass rate on Integration and Unit tests across all services.

--- a/docs/INCREMENT_2_PLAN_1.md
+++ b/docs/INCREMENT_2_PLAN_1.md
@@ -129,17 +129,17 @@ graph TD
     
     %% Storage
     DBs[("Fleet & Route DBs")]:::db
-    PostgresDBs[("ETA & Anomaly DBs (PostgreSQL)")]:::db
-    InfluxDB[("InfluxDB (Offline Training)")]:::db
+    PostgresDBs[("ETA & Anomaly DBs<br>(PostgreSQL)")]:::db
+    InfluxDB[("InfluxDB<br>(Offline Training)")]:::db
     
     %% ML / Analytics
     ETA["ETA Service Inference"]:::ml
-    AnomalyML["Anomaly Service (Isolation Forest)"]:::ml
+    AnomalyML["Anomaly Service<br>(Isolation Forest)"]:::ml
     
     %% Delivery
-    Redis[("Redis PubSub (fleet, eta, anomaly)")]:::pubsub
+    Redis[("Redis PubSub<br>(fleet, eta, anomaly)")]:::pubsub
     WSService["WebSocket Service"]:::pubsub
-    Kong["G4 Kong Gateway (Routing Bypass)"]:::gateway
+    Kong["G4 Kong API Gateway"]:::gateway
 
     %% Logical Flow
     Ingestion --> FlinkCore

--- a/docs/INCREMENT_2_PLAN_1.md
+++ b/docs/INCREMENT_2_PLAN_1.md
@@ -113,47 +113,54 @@ Triggered by rules or Isolation Forest ML.
 
 ```mermaid
 graph TD
-    classDef janidu fill:#d5e8d4,stroke:#82b366,stroke-width:2px;
-    classDef natasha fill:#dae8fc,stroke:#6c8ebf,stroke-width:2px;
-    classDef chamodh fill:#ffe6cc,stroke:#d79b00,stroke-width:2px;
-    classDef kusal fill:#f8cecc,stroke:#b85450,stroke-width:2px;
-    classDef nidharshan fill:#e1d5e7,stroke:#9673a6,stroke-width:2px;
+    classDef ingest fill:#dae8fc,stroke:#6c8ebf,stroke-width:2px;
+    classDef stream fill:#ffe6cc,stroke:#d79b00,stroke-width:2px;
+    classDef ml fill:#e1d5e7,stroke:#9673a6,stroke-width:2px;
+    classDef db fill:#d5e8d4,stroke:#82b366,stroke-width:2px;
+    classDef pubsub fill:#f8cecc,stroke:#b85450,stroke-width:2px;
+    classDef gateway fill:#f5f5f5,stroke:#666666,stroke-width:2px;
 
-    Ingestion["Ingestion Service<br>(Janidu)"]:::janidu
-    FlinkCore["Flink Deduplication / Physics<br>(Janidu)"]:::janidu
+    %% Data Sources & Ingestion
+    Ingestion["Ingestion Service"]:::ingest
     
-    FlinkEnrich["Flink PostGIS / Enrichment<br>(Natasha)"]:::natasha
-    AnomalyML["Anomaly Service Models<br>(Natasha)"]:::natasha
+    %% Stream Processing
+    FlinkCore["Flink Deduplication / Physics"]:::stream
+    FlinkEnrich["Flink PostGIS / Enrichment"]:::stream
     
-    DBs["Fleet & Route Services / DBs<br>(Chamodh)"]:::chamodh
-    PostgresDBs["ETA & Anomaly DBs (PostgreSQL)<br>(Chamodh)"]:::chamodh
-    InfluxDB[("InfluxDB<br>(Offline Training)")]:::natasha
+    %% Storage
+    DBs[("Fleet & Route DBs")]:::db
+    PostgresDBs[("ETA & Anomaly DBs (PostgreSQL)")]:::db
+    InfluxDB[("InfluxDB (Offline Training)")]:::db
     
-    ETA["ETA Service Inference<br>(Kusal)"]:::kusal
+    %% ML / Analytics
+    ETA["ETA Service Inference"]:::ml
+    AnomalyML["Anomaly Service (Isolation Forest)"]:::ml
     
-    Redis["Redis PubSub<br>(fleet, eta, anomaly)<br>(Nidharshan)"]:::nidharshan
-    WSService["WebSocket Service<br>(Nidharshan)"]:::nidharshan
-    Kong["G4 Kong Gateway<br>(Routing Bypass)"]:::nidharshan
+    %% Delivery
+    Redis[("Redis PubSub (fleet, eta, anomaly)")]:::pubsub
+    WSService["WebSocket Service"]:::pubsub
+    Kong["G4 Kong Gateway (Routing Bypass)"]:::gateway
 
+    %% Logical Flow
     Ingestion --> FlinkCore
     FlinkCore --> FlinkEnrich
-    DBs -.-> FlinkEnrich
+    DBs -.->|Startup Cache| FlinkEnrich
     
-    FlinkEnrich --> AnomalyML
-    AnomalyML --> PostgresDBs
+    FlinkEnrich -->|Enriched Data| ETA
+    FlinkEnrich -->|Enriched Data| AnomalyML
     
-    FlinkEnrich --> ETA
-    ETA --> PostgresDBs
+    InfluxDB -.->|Model Training| ETA
+    InfluxDB -.->|Model Training| AnomalyML
     
-    InfluxDB -.->|Offline Training| ETA
-    InfluxDB -.->|Offline Training| AnomalyML
+    ETA -->|Persistent| PostgresDBs
+    AnomalyML -->|Persistent| PostgresDBs
     
-    FlinkEnrich --> Redis
-    ETA --> Redis
-    AnomalyML --> Redis
+    FlinkEnrich -->|Live State| Redis
+    ETA -->|Live ETA| Redis
+    AnomalyML -->|Live Alerts| Redis
     
-    Redis --> WSService
-    WSService --> Kong
+    Redis -->|PubSub| WSService
+    WSService -->|WS Stream| Kong
 ```
 
 ---


### PR DESCRIPTION
## Purpose

This PR documents the **next implementation phase** for the ETA pipeline (building on PR #92).
No code changes — plan only. Requesting approval before any implementation begins.

---

## What this proposes

| Phase | Description | Files affected |
|-------|-------------|----------------|
| **1** | Add `offRoute` + `offRouteDistanceM` fields to Flink enriched stream | `stream-processing/` |
| **2** | `PERSISTENT_OFF_ROUTE` anomaly alert after 3 consecutive off-route readings | `anomaly-service/` |
| **3** | New `eta_db` logical database (same Postgres container, pattern of `fleet_db`) | `docker/` |
| **4** | ETA Service: skip Redis/eta:live when off-route; persist valid ETAs to `eta_records` | `eta-service/` |
| **5** | SARIMA time-series forecasting offline CLI + `?model=sarima` HTTP endpoint | `eta-service/` |

---

## Key design decisions

- `offRoute` threshold: **50 m** — consistent with existing Anomaly Service `OFF_ROUTE` check
- Streak threshold: **3 consecutive readings** (~3 s at 1 fix/s — not GPS noise)
- `eta_db` on same Postgres container — **no new Docker service**; same isolation pattern as `fleet_db`
- Schema owned by `create_all()` at startup — lightweight, no root Alembic changes
- SARIMA is **offline/manual only** — `train_sarima.py` CLI, not a background task
- XGBoost pipeline (PR #92) is **not replaced** — SARIMA adds a third `?model=` option
- All changes to `transport-telemetry-cleaned` are **additive** — no existing consumers broken

---

## Open questions (please comment)

1. **`eta_records` retention** — cron DELETE vs Postgres partitioning by month?
2. **SARIMA minimum sample threshold** — 48 h (2 cycles) or 24 h (1 cycle)?
3. **Off-route streak policy** — count-based (3 readings) or time-based (e.g. 5 s window)?
4. **`eta_db` schema ownership** — `create_all()` at startup or lightweight Alembic inside `services/eta-service/`?

---

## CI impact

This PR adds **only a markdown document** — no code, no dependencies, no migrations.
All existing CI workflows pass unchanged.