### PR TITLE
fix: create Keycloak users with permanent passwords

### DIFF
--- a/services/api-gateway/app/services/keycloak_client.py
+++ b/services/api-gateway/app/services/keycloak_client.py
@@ -38,7 +38,7 @@ class KeycloakClient:
                 "enabled": True,
                 "firstName": first_name,
                 "lastName": last_name,
-                "credentials": [{"value": password, "type": "password", "temporary": True}] # Force change
+                "credentials": [{"value": password, "type": "password", "temporary": False}]
             }, exist_ok=False)
             
             # Assign the role


### PR DESCRIPTION
## Summary
- Change `temporary: True` to `temporary: False` when creating Keycloak driver users
- Prevents the forced password-change flow that blocks ROPC (direct grant) login on driver web

## Root cause
Drivers created via admin web could not log in via the custom credentials form because Keycloak flagged their accounts as "not fully set up" due to the `UPDATE_PASSWORD` required action triggered by temporary credentials.