### PR TITLE
feat(eta+anomaly): SARIMA ETA forecasting + IsolationForest anomaly detection + websocket eta fix

### DIFF
--- a/docs/FRONTEND_SOCKET_ETA_FIX.md
+++ b/docs/FRONTEND_SOCKET_ETA_FIX.md
@@ -1,0 +1,113 @@
+# Frontend Socket Service Fix — ETA always showing 0 min
+
+## Root Cause
+
+`consumer.py` (eta-service) emits ETA events to the `eta:live` Redis channel with payload:
+```json
+{ "event": "eta_update", "busId": "1", "eta_seconds": 315.0, "eta": 5.3, ... }
+```
+
+**websocket-service** now injects `eta` (minutes) via commit `a262f0f`. However
+`socketService.ts` in both frontend repos constructs a full `BusLocation` from every
+WebSocket message, using:
+
+```ts
+lat:   Number(raw.lat ?? 0),    // raw.lat is undefined for eta_update messages
+lng:   Number(raw.lon ?? raw.lng ?? 0),  // → 0
+speed: Number(raw.speed ?? 0),  // → 0
+eta:   Number(raw.eta ?? 0),    // ← NOW WORKS (after a262f0f) but lat/lng/speed become 0
+```
+
+This means `eta_update` messages **clobber the stored bus with lat=0, lng=0, speed=0**
+even though `eta` is now correctly populated.
+
+## Fix Strategy
+
+Keep a `busCache` Map inside `SocketService`. On every `bus:location`-type message
+(i.e. when `raw.event !== "eta_update"`), update the cache with the full object.
+On `eta_update` messages, retrieve the cached bus and merge only the `eta` field
+before dispatching.
+
+## Exact Patch — `src/lib/socket/socketService.ts` (passenger-web)
+
+**File**: `src/lib/socket/socketService.ts`
+
+Replace the class body `private listeners` section and `_open()` `onmessage` handler:
+
+```diff
+ class SocketService {
+   private ws: WebSocket | null = null;
+   private listeners: Listeners = new Map();
++  private busCache: Map<string, BusLocation> = new Map();
+   private url = '';
+   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+   private reconnectAttempts = 0;
+   private readonly maxReconnects = 5;
+```
+
+And in `onmessage`:
+
+```diff
+     this.ws.onmessage = (event) => {
+       try {
+         const raw = JSON.parse(event.data as string);
++
++        // --- eta_update: only refresh eta for an existing cached bus ---
++        if (raw.event === 'eta_update') {
++          const busId = String(raw.busId ?? raw.bus_id ?? '');
++          const cached = this.busCache.get(busId);
++          if (cached) {
++            const merged: BusLocation = { ...cached, eta: Number(raw.eta ?? cached.eta) };
++            this.busCache.set(busId, merged);
++            this._dispatch('bus:location', merged);
++          }
++          return;
++        }
++
+         const location: BusLocation = {
+           busId:      String(raw.busId ?? raw.bus_id ?? ''),
+           routeId:    String(raw.routeId ?? raw.route_id ?? ''),
+           lat:        Number(raw.lat ?? 0),
+           lng:        Number(raw.lon ?? raw.lng ?? 0),
+           speed:      Number(raw.speed ?? 0),
+           heading:    Number(raw.heading ?? 0),
+           timestamp:  Number(raw.timestamp ?? Date.now()),
+           occupancy:  raw.occupancy ?? 'low',
+           status:     raw.status ?? 'active',
+           driverName: raw.driverName ?? 'Unknown',
+           eta:        Number(raw.eta ?? 0),
+         };
++        this.busCache.set(location.busId, location);
+         this._dispatch('bus:location', location);
+       } catch (e) {
+         console.error('[Socket] Parse error:', e);
+       }
+     };
+```
+
+## Exact Patch — `lib/socket/socketService.ts` (admin-web)
+
+**File**: `lib/socket/socketService.ts`  
+**Identical changes** — same class, same `onmessage` handler, same `busCache` field.
+
+## Commit Messages
+
+```
+fix(socket): merge eta_update into cached bus — prevent lat/lng/speed zero-clobber
+
+eta_update WebSocket messages carry only {busId, eta, eta_seconds, event}.
+Constructing a full BusLocation from them sets lat=lng=speed=0.
+
+Fix: add busCache Map<busId, BusLocation>.
+- fleet:live messages (bus:location events): update cache + dispatch as before
+- eta_update messages: merge only `eta` into cached bus + dispatch merged object
+  If no cached bus yet, skip dispatch (will arrive with next fleet:live tick)
+```
+
+## Testing
+
+After this fix with the noderoad GPS simulation running:
+1. Open tracking page for any bus
+2. ETA stat card should show a non-zero value (e.g. "5.3 min")
+3. Bus marker should not jump to (0, 0) when an eta_update arrives
+4. Refreshing should immediately show the cached position

--- a/services/anomaly-service/Dockerfile
+++ b/services/anomaly-service/Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /opt/anomaly-service
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Create directory for the IsolationForest artifact (mounted or built-in at deploy time)
+RUN mkdir -p /opt/anomaly-service/if_artifacts
+ENV ANOMALY_IF_ARTIFACT_PATH=/opt/anomaly-service/if_artifacts/isolation_forest.joblib
+
 COPY app ./app
 
 CMD ["python", "-m", "app.main"]

--- a/services/anomaly-service/Dockerfile
+++ b/services/anomaly-service/Dockerfile
@@ -6,8 +6,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Create directory for the IsolationForest artifact (mounted or built-in at deploy time)
-RUN mkdir -p /opt/anomaly-service/if_artifacts
-ENV ANOMALY_IF_ARTIFACT_PATH=/opt/anomaly-service/if_artifacts/isolation_forest.joblib
+RUN mkdir -p /opt/anomaly-service/app/models/training
+ENV ANOMALY_ISOLATION_FOREST_ARTIFACT_PATH=/opt/anomaly-service/app/models/training/isolation_forest.joblib
 
 COPY app ./app
 

--- a/services/anomaly-service/app/main.py
+++ b/services/anomaly-service/app/main.py
@@ -39,7 +39,7 @@ def route_geometry_to_points(route: dict) -> list[tuple[float, float]]:
 
 class AnomalyService:
     def __init__(self):
-        self.model = AnomalyModel()
+        self.model = AnomalyModel(artifact_path=settings.if_artifact_path)
         self.route_geometries = {}
         self.redis_client = None
         try:

--- a/services/anomaly-service/app/main.py
+++ b/services/anomaly-service/app/main.py
@@ -39,7 +39,7 @@ def route_geometry_to_points(route: dict) -> list[tuple[float, float]]:
 
 class AnomalyService:
     def __init__(self):
-        self.model = AnomalyModel(artifact_path=settings.if_artifact_path)
+        self.model = AnomalyModel(artifact_path=settings.isolation_forest_artifact_path)
         self.route_geometries = {}
         self.redis_client = None
         try:

--- a/services/anomaly-service/app/models/anomaly_model.py
+++ b/services/anomaly-service/app/models/anomaly_model.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Tuple
 from app.config import settings
 from .training.feature_extraction import build_summary_vector
 
+from models.isolation_forest_model import predict as if_predict
+
 logger = logging.getLogger(__name__)
 
 def haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
@@ -58,8 +60,9 @@ def distance_to_polyline(lat: float, lon: float, polyline: List[Tuple[float, flo
 
 
 class AnomalyModel:
-    def __init__(self):
+    def __init__(self, artifact_path: str = ""):
         self.version = "rules-v1"
+        self.artifact_path = artifact_path
         self.bus_states = {}  # { busId: { last_timestamp, last_telemetry, stationary_start_time } }
         self.inactive_trip_states = {}  # { busId: { timestamps, last_alert_timestamp } }
         self.off_route_states = {}  # { busId: { count, window_start_ts, alerted } }
@@ -92,6 +95,34 @@ class AnomalyModel:
         route_id = telemetry.get("routeId")
 
         current_time = self._parse_timestamp(ts_str)
+
+        # --- IsolationForest ML scoring (pre-rule, unsupervised) ---
+        dist_to_route = distance_to_polyline(lat, lon, route_geometry) if route_geometry else 0.0
+        prev_state = self.bus_states.get(bus_id, {})
+        prev_heading = (prev_state.get("last_telemetry") or {}).get("heading", telemetry.get("heading", 0.0))
+        curr_heading = telemetry.get("heading", 0.0)
+        heading_delta = abs(curr_heading - prev_heading) % 360
+        heading_delta = min(heading_delta, 360 - heading_delta)
+        route_progress = telemetry.get("routeProgressPct", 0.0) or 0.0
+        hour_of_day = datetime.now(timezone.utc).hour
+        if self.artifact_path:
+            speed_ms = speed / 3.6 if speed > 10 else speed  # convert km/h → m/s
+            if_result = if_predict(
+                speed_ms=speed_ms,
+                distance_to_route_m=dist_to_route,
+                heading_delta_deg=heading_delta,
+                route_progress_pct=route_progress,
+                hour_of_day=hour_of_day,
+            )
+            if if_result is not None:
+                is_anomaly, if_score = if_result
+                if is_anomaly:
+                    alerts.append(self._create_alert(
+                        bus_id, "ML_ANOMALY",
+                        f"IsolationForest anomaly score {if_score:.3f}",
+                        telemetry,
+                        extra={"if_score": if_score},
+                    ))
 
         # 1. Unrealistic Speed
         if speed > 120.0:

--- a/services/anomaly-service/app/models/isolation_forest_model.py
+++ b/services/anomaly-service/app/models/isolation_forest_model.py
@@ -1,0 +1,132 @@
+"""IsolationForest anomaly detector — production inference module.
+
+Loads a pre-trained sklearn IsolationForest artifact from disk and scores
+each GPS telemetry observation against the normal-operation distribution.
+
+Training
+--------
+Use services/anomaly-service/models/training/train_isolation_forest.py to
+fit the model offline from historical GPS telemetry (unsupervised — no
+anomaly labels needed). The artifact is saved to ANOMALY_IF_ARTIFACT_DIR.
+
+Feature vector (5 dimensions)
+------------------------------
+  0  speed_ms            — effective speed in m/s
+  1  distance_to_route_m — metres from bus position to nearest route polyline point
+  2  heading_delta_deg   — absolute bearing change from previous fix (0–180°)
+  3  route_progress_pct  — 0–100 % along the assigned route
+  4  hour_of_day         — 0–23 integer (captures time-of-day seasonality)
+
+Fallback contract
+-----------------
+predict() returns None when:
+  - No artifact file exists (model not yet trained)
+  - Any exception during scoring
+Callers must fall back to the rule-based detector in that case.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Overridable at startup via env var / app.config
+_ARTIFACT_DIR: str = os.getenv("ANOMALY_IF_ARTIFACT_DIR", "if_artifacts")
+_ARTIFACT_FILENAME: str = "isolation_forest.joblib"
+
+
+def _artifact_path() -> str:
+    return os.path.join(_ARTIFACT_DIR, _ARTIFACT_FILENAME)
+
+
+@lru_cache(maxsize=1)
+def _load_model():
+    """Load (and cache) the fitted IsolationForest from disk.
+
+    Returns the model object, or None if the artifact does not exist.
+    Uses lru_cache so the file is read at most once per worker process.
+    """
+    path = _artifact_path()
+    if not os.path.exists(path):
+        logger.debug("No IsolationForest artifact at %s — rule-based fallback active", path)
+        return None
+    try:
+        import joblib
+
+        model = joblib.load(path)
+        logger.info("Loaded IsolationForest artifact from %s", path)
+        return model
+    except Exception as exc:
+        logger.error("Failed to load IsolationForest artifact %s: %s", path, exc)
+        return None
+
+
+def build_feature_vector(
+    speed_ms: float,
+    distance_to_route_m: float,
+    heading_delta_deg: float,
+    route_progress_pct: float,
+    hour_of_day: int,
+) -> list[float]:
+    """Return the 5-element feature vector in training order."""
+    return [
+        float(speed_ms),
+        float(distance_to_route_m),
+        float(max(0.0, min(180.0, heading_delta_deg))),
+        float(max(0.0, min(100.0, route_progress_pct))),
+        float(max(0, min(23, hour_of_day))),
+    ]
+
+
+def predict(
+    speed_ms: float,
+    distance_to_route_m: float,
+    heading_delta_deg: float,
+    route_progress_pct: float,
+    hour_of_day: int,
+) -> Optional[tuple[bool, float]]:
+    """Score one telemetry observation against the IsolationForest model.
+
+    Parameters
+    ----------
+    speed_ms            : effective bus speed in m/s
+    distance_to_route_m : perpendicular distance to nearest polyline point (metres)
+    heading_delta_deg   : absolute heading change from previous GPS fix (0–180°)
+    route_progress_pct  : percentage progress along the route (0–100)
+    hour_of_day         : UTC hour of the GPS fix (0–23)
+
+    Returns
+    -------
+    (is_anomaly, anomaly_score) tuple, where:
+        is_anomaly    : True when IsolationForest predicts -1 (outlier)
+        anomaly_score : raw decision_function score (more negative = more anomalous)
+    None
+        When no artifact exists or prediction raises an exception.
+    """
+    model = _load_model()
+    if model is None:
+        return None
+
+    features = build_feature_vector(
+        speed_ms,
+        distance_to_route_m,
+        heading_delta_deg,
+        route_progress_pct,
+        hour_of_day,
+    )
+
+    try:
+        import numpy as np
+
+        X = np.array([features])
+        label = int(model.predict(X)[0])          # 1 = normal, -1 = anomaly
+        score = float(model.decision_function(X)[0])  # lower = more anomalous
+        is_anomaly = label == -1
+        return is_anomaly, score
+    except Exception as exc:
+        logger.error("IsolationForest prediction failed: %s", exc)
+        return None

--- a/services/anomaly-service/app/models/isolation_forest_model.py
+++ b/services/anomaly-service/app/models/isolation_forest_model.py
@@ -32,6 +32,13 @@ import os
 from functools import lru_cache
 from typing import Optional
 
+try:
+    import joblib
+    import numpy as np
+except ImportError:  # not installed — feature degrades gracefully
+    joblib = None  # type: ignore[assignment]
+    np = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
 
 # Overridable at startup via env var / app.config
@@ -55,8 +62,9 @@ def _load_model():
         logger.debug("No IsolationForest artifact at %s — rule-based fallback active", path)
         return None
     try:
-        import joblib
-
+        if joblib is None:
+            logger.warning("joblib not installed — IsolationForest unavailable")
+            return None
         model = joblib.load(path)
         logger.info("Loaded IsolationForest artifact from %s", path)
         return model
@@ -120,8 +128,9 @@ def predict(
     )
 
     try:
-        import numpy as np
-
+        if np is None:
+            logger.warning("numpy not installed — IsolationForest unavailable")
+            return None
         X = np.array([features])
         label = int(model.predict(X)[0])          # 1 = normal, -1 = anomaly
         score = float(model.decision_function(X)[0])  # lower = more anomalous

--- a/services/anomaly-service/models/training/train_isolation_forest.py
+++ b/services/anomaly-service/models/training/train_isolation_forest.py
@@ -1,0 +1,343 @@
+"""Offline IsolationForest training CLI for the Anomaly Service.
+
+Reads historical GPS telemetry from InfluxDB (normal operating data only —
+unsupervised approach; no anomaly labels needed), engineers the 5-dimensional
+feature vector, fits an IsolationForest, evaluates on a 20% hold-out, and
+saves the artifact to ANOMALY_IF_ARTIFACT_DIR/isolation_forest.joblib.
+
+Feature vector
+--------------
+  0  speed_ms            (m/s)
+  1  distance_to_route_m (m)    — requires route geometry from route-service
+  2  heading_delta_deg   (0–180°)
+  3  route_progress_pct  (0–100)
+  4  hour_of_day         (0–23)
+
+Usage
+-----
+    python -m models.training.train_isolation_forest \\
+        --influxdb-url   http://localhost:8086 \\
+        --influxdb-token <token> \\
+        --influxdb-org   ontime \\
+        --influxdb-bucket telemetry \\
+        --route-service-url http://localhost:8002 \\
+        --artifact-dir   if_artifacts \\
+        --contamination  0.05 \\
+        --n-estimators   100
+
+Environment overrides
+---------------------
+  INFLUXDB_URL          INFLUXDB_TOKEN    INFLUXDB_ORG    INFLUXDB_BUCKET
+  ANOMALY_ROUTE_SERVICE_URL               ANOMALY_IF_ARTIFACT_DIR
+  ANOMALY_IF_CONTAMINATION                ANOMALY_IF_N_ESTIMATORS
+
+Design notes
+------------
+- Queries the last 7 days of telemetry by default (--lookback-hours 168)
+- Only rows with a non-null routeId are included (GPS noise / inactive-trip
+  rows would corrupt the normal-operation distribution)
+- Route geometry is fetched lazily from route-service, cached in memory
+- heading_delta computed from consecutive GPS fixes within the same bus/route
+- 20% stratified time-split hold-out (last 20% of timestamps per bus)
+- Prints: contamination fraction, n_estimators, n_samples_train, F1 proxy
+  (fraction of hold-out flagged as anomalous ≈ contamination if well-fitted)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import os
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Fit IsolationForest on GPS telemetry history (unsupervised)."
+    )
+    p.add_argument("--influxdb-url",    default=os.getenv("INFLUXDB_URL",    "http://localhost:8086"))
+    p.add_argument("--influxdb-token",  default=os.getenv("INFLUXDB_TOKEN",  ""))
+    p.add_argument("--influxdb-org",    default=os.getenv("INFLUXDB_ORG",    "ontime"))
+    p.add_argument("--influxdb-bucket", default=os.getenv("INFLUXDB_BUCKET", "telemetry"))
+    p.add_argument("--route-service-url", default=os.getenv("ANOMALY_ROUTE_SERVICE_URL", "http://route-service:8002"))
+    p.add_argument("--artifact-dir",    default=os.getenv("ANOMALY_IF_ARTIFACT_DIR", "if_artifacts"))
+    p.add_argument("--contamination",   type=float, default=float(os.getenv("ANOMALY_IF_CONTAMINATION", "0.05")))
+    p.add_argument("--n-estimators",    type=int,   default=int(os.getenv("ANOMALY_IF_N_ESTIMATORS",    "100")))
+    p.add_argument("--lookback-hours",  type=int,   default=168, help="Hours of history to fetch (default 168 = 7 days)")
+    p.add_argument("--random-state",    type=int,   default=42)
+    return p.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# InfluxDB fetch
+# ---------------------------------------------------------------------------
+
+def _fetch_telemetry(url: str, token: str, org: str, bucket: str, lookback_hours: int) -> "pd.DataFrame":
+    """Pull GPS telemetry from InfluxDB into a DataFrame."""
+    from influxdb_client import InfluxDBClient
+    import pandas as pd
+
+    flux_query = f"""
+    from(bucket: "{bucket}")
+      |> range(start: -{lookback_hours}h)
+      |> filter(fn: (r) => r._measurement == "bus_telemetry")
+      |> filter(fn: (r) => r._field == "lat" or r._field == "lon"
+                         or r._field == "speed" or r._field == "heading"
+                         or r._field == "routeProgressPct")
+      |> pivot(rowKey: ["_time", "busId", "routeId"], columnKey: ["_field"], valueColumn: "_value")
+      |> filter(fn: (r) => exists r.routeId)
+      |> sort(columns: ["busId", "_time"])
+    """
+
+    with InfluxDBClient(url=url, token=token, org=org) as client:
+        df = client.query_api().query_data_frame(flux_query, org=org)
+
+    if df.empty:
+        raise ValueError("InfluxDB returned no telemetry rows. Check --lookback-hours or bucket name.")
+
+    df = df.rename(columns={"_time": "timestamp"})
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    logger.info("Fetched %d telemetry rows from InfluxDB", len(df))
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Route geometry fetch
+# ---------------------------------------------------------------------------
+
+def _fetch_route_geometry(route_service_url: str, route_id: str, _cache: dict) -> list:
+    """Return polyline as list of (lat, lon) tuples; cached per route_id."""
+    if route_id in _cache:
+        return _cache[route_id]
+    try:
+        import httpx
+
+        resp = httpx.get(f"{route_service_url}/api/v1/internal/routes/{route_id}/geometry", timeout=10)
+        resp.raise_for_status()
+        coords = resp.json().get("coordinates", [])
+        polyline = [(c["lat"], c["lon"]) for c in coords]
+    except Exception as exc:
+        logger.warning("Could not fetch geometry for route %s: %s", route_id, exc)
+        polyline = []
+    _cache[route_id] = polyline
+    return polyline
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers (inline to avoid app.models import)
+# ---------------------------------------------------------------------------
+
+def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    R = 6_371_000
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp, dl = math.radians(lat2 - lat1), math.radians(lon2 - lon1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _dist_to_polyline(lat: float, lon: float, polyline: list) -> float:
+    if not polyline:
+        return 0.0
+    min_d = float("inf")
+    for i in range(len(polyline) - 1):
+        p1, p2 = polyline[i], polyline[i + 1]
+        seg = _haversine(*p1, *p2)
+        if seg == 0:
+            min_d = min(min_d, _haversine(lat, lon, *p1))
+            continue
+        d1 = _haversine(lat, lon, *p1)
+        d2 = _haversine(lat, lon, *p2)
+        t = max(0.0, min(1.0, (d1 ** 2 + seg ** 2 - d2 ** 2) / (2 * seg ** 2)))
+        proj = (p1[0] + t * (p2[0] - p1[0]), p1[1] + t * (p2[1] - p1[1]))
+        min_d = min(min_d, _haversine(lat, lon, *proj))
+    return min_d
+
+
+def _heading_delta(h1: float, h2: float) -> float:
+    """Absolute angular difference between two headings (0–180°)."""
+    delta = abs(h1 - h2) % 360
+    return min(delta, 360 - delta)
+
+
+# ---------------------------------------------------------------------------
+# Feature engineering
+# ---------------------------------------------------------------------------
+
+def _engineer_features(df: "pd.DataFrame", route_service_url: str) -> "pd.DataFrame":
+    """Add feature columns to df in-place; return rows with all features valid."""
+    import numpy as np
+
+    route_cache: dict = {}
+
+    # distance_to_route_m
+    def _dist_row(row):
+        poly = _fetch_route_geometry(route_service_url, str(row["routeId"]), route_cache)
+        return _dist_to_polyline(row["lat"], row["lon"], poly)
+
+    logger.info("Computing distance_to_route_m for %d rows (may be slow)...", len(df))
+    df["distance_to_route_m"] = df.apply(_dist_row, axis=1)
+
+    # heading_delta_deg — difference from previous fix of same bus
+    df = df.sort_values(["busId", "timestamp"]).copy()
+    df["prev_heading"] = df.groupby("busId")["heading"].shift(1)
+    df["heading_delta_deg"] = df.apply(
+        lambda r: _heading_delta(r["heading"], r["prev_heading"])
+        if not (np.isnan(r["heading"]) or np.isnan(r.get("prev_heading", float("nan"))))
+        else 0.0,
+        axis=1,
+    )
+
+    # hour_of_day
+    df["hour_of_day"] = df["timestamp"].dt.hour
+
+    # speed in m/s (raw field is km/h in telemetry)
+    if df["speed"].max() > 50:  # heuristic: likely km/h
+        df["speed_ms"] = df["speed"] / 3.6
+    else:
+        df["speed_ms"] = df["speed"]
+
+    # route_progress_pct — use as-is or 0
+    if "routeProgressPct" not in df.columns:
+        df["route_progress_pct"] = 0.0
+    else:
+        df["route_progress_pct"] = df["routeProgressPct"].fillna(0.0)
+
+    feature_cols = [
+        "speed_ms", "distance_to_route_m", "heading_delta_deg",
+        "route_progress_pct", "hour_of_day",
+    ]
+    return df[feature_cols].dropna()
+
+
+# ---------------------------------------------------------------------------
+# Train + evaluate
+# ---------------------------------------------------------------------------
+
+def _train_and_evaluate(
+    X_train: "np.ndarray",
+    X_test: "np.ndarray",
+    n_estimators: int,
+    contamination: float,
+    random_state: int,
+) -> object:
+    from sklearn.ensemble import IsolationForest
+
+    model = IsolationForest(
+        n_estimators=n_estimators,
+        contamination=contamination,
+        random_state=random_state,
+        n_jobs=-1,
+    )
+    model.fit(X_train)
+    logger.info("Fitted IsolationForest on %d training samples", len(X_train))
+
+    if len(X_test) > 0:
+        preds = model.predict(X_test)         # 1 = normal, -1 = anomaly
+        flagged = (preds == -1).sum()
+        flag_rate = flagged / len(X_test)
+        logger.info(
+            "Hold-out (%d samples): flagged %d (%.1f%%) as anomalous "
+            "(contamination=%.2f — expect ~%.1f%%)",
+            len(X_test), flagged, flag_rate * 100,
+            contamination, contamination * 100,
+        )
+
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    args = _parse_args()
+
+    try:
+        import numpy as np
+        import pandas as pd
+        from sklearn.ensemble import IsolationForest  # noqa: F401
+        import joblib
+    except ImportError as exc:
+        logger.error("Missing dependency: %s  (run: pip install scikit-learn joblib influxdb-client httpx pandas)", exc)
+        return 1
+
+    if not args.influxdb_token:
+        logger.error("--influxdb-token / INFLUXDB_TOKEN is required.")
+        return 1
+
+    artifact_dir = Path(args.artifact_dir)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------ #
+    # 1. Fetch                                                             #
+    # ------------------------------------------------------------------ #
+    try:
+        df = _fetch_telemetry(
+            args.influxdb_url, args.influxdb_token,
+            args.influxdb_org, args.influxdb_bucket,
+            args.lookback_hours,
+        )
+    except Exception as exc:
+        logger.error("Failed to fetch from InfluxDB: %s", exc)
+        return 1
+
+    # ------------------------------------------------------------------ #
+    # 2. Engineer features                                                 #
+    # ------------------------------------------------------------------ #
+    try:
+        features_df = _engineer_features(df, args.route_service_url)
+    except Exception as exc:
+        logger.error("Feature engineering failed: %s", exc)
+        return 1
+
+    if len(features_df) < 50:
+        logger.error(
+            "Only %d feature rows — need at least 50 to train. "
+            "Increase --lookback-hours or check InfluxDB bucket.",
+            len(features_df),
+        )
+        return 1
+
+    X = features_df.values.astype(np.float64)
+
+    # ------------------------------------------------------------------ #
+    # 3. 80/20 time-ordered split                                         #
+    # ------------------------------------------------------------------ #
+    split = int(len(X) * 0.8)
+    X_train, X_test = X[:split], X[split:]
+
+    # ------------------------------------------------------------------ #
+    # 4. Train + evaluate                                                  #
+    # ------------------------------------------------------------------ #
+    model = _train_and_evaluate(
+        X_train, X_test,
+        n_estimators=args.n_estimators,
+        contamination=args.contamination,
+        random_state=args.random_state,
+    )
+
+    # ------------------------------------------------------------------ #
+    # 5. Save artifact                                                     #
+    # ------------------------------------------------------------------ #
+    out_path = artifact_dir / "isolation_forest.joblib"
+    joblib.dump(model, out_path)
+    logger.info("Artifact saved → %s", out_path.resolve())
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/anomaly-service/requirements.txt
+++ b/services/anomaly-service/requirements.txt
@@ -8,3 +8,5 @@ pytest-asyncio
 sqlalchemy>=2.0
 psycopg2-binary
 redis>=5.0
+scikit-learn>=1.3
+joblib>=1.3

--- a/services/anomaly-service/tests/unit/test_isolation_forest_model.py
+++ b/services/anomaly-service/tests/unit/test_isolation_forest_model.py
@@ -1,0 +1,172 @@
+"""Unit tests for isolation_forest_model.py."""
+
+import os
+import importlib
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reload_module():
+    """Re-import the module so @lru_cache state is cleared between tests."""
+    import app.models.isolation_forest_model as m
+    importlib.reload(m)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Missing artifact → predict returns None
+# ---------------------------------------------------------------------------
+
+class TestMissingArtifact:
+    def test_predict_returns_none_when_no_file(self, tmp_path):
+        mod = _reload_module()
+        # Point artifact dir at an empty directory (file does not exist)
+        nonexistent = str(tmp_path / "no_model.joblib")
+        with patch.object(mod, "_artifact_path", return_value=nonexistent):
+            # Reload lru_cache by reloading the module again
+            importlib.reload(mod)
+            result = mod.predict(
+                speed_ms=10.0,
+                distance_to_route_m=5.0,
+                heading_delta_deg=15.0,
+                route_progress_pct=30.0,
+                hour_of_day=8,
+            )
+        assert result is None
+
+    def test_load_model_returns_none_when_no_file(self, tmp_path):
+        mod = _reload_module()
+        nonexistent = str(tmp_path / "no_model.joblib")
+        with patch.object(mod, "_artifact_path", return_value=nonexistent):
+            importlib.reload(mod)
+            assert mod._load_model() is None
+
+
+# ---------------------------------------------------------------------------
+# Valid artifact → predict returns (bool, float)
+# ---------------------------------------------------------------------------
+
+class TestValidArtifact:
+    def _make_mock_model(self, *, label: int, score: float):
+        """Return a mock IsolationForest that returns predetermined outputs."""
+        import numpy as np
+
+        mock = MagicMock()
+        mock.predict.return_value = [label]
+        mock.decision_function.return_value = [score]
+        return mock
+
+    def test_predict_normal_returns_false(self, tmp_path):
+        mod = _reload_module()
+        mock_model = self._make_mock_model(label=1, score=0.12)
+        with patch.object(mod, "_load_model", return_value=mock_model):
+            result = mod.predict(
+                speed_ms=8.0,
+                distance_to_route_m=12.0,
+                heading_delta_deg=5.0,
+                route_progress_pct=50.0,
+                hour_of_day=14,
+            )
+        assert result is not None
+        is_anomaly, score = result
+        assert is_anomaly is False
+        assert isinstance(score, float)
+        assert score == pytest.approx(0.12)
+
+    def test_predict_anomaly_returns_true(self, tmp_path):
+        mod = _reload_module()
+        mock_model = self._make_mock_model(label=-1, score=-0.45)
+        with patch.object(mod, "_load_model", return_value=mock_model):
+            result = mod.predict(
+                speed_ms=45.0,
+                distance_to_route_m=300.0,
+                heading_delta_deg=170.0,
+                route_progress_pct=5.0,
+                hour_of_day=2,
+            )
+        assert result is not None
+        is_anomaly, score = result
+        assert is_anomaly is True
+        assert score == pytest.approx(-0.45)
+
+    def test_predict_passes_correct_feature_count(self):
+        """predict() must call model.predict with a (1, 5) shaped array."""
+        import numpy as np
+        mod = _reload_module()
+        mock_model = MagicMock()
+        mock_model.predict.return_value = [1]
+        mock_model.decision_function.return_value = [0.1]
+
+        with patch.object(mod, "_load_model", return_value=mock_model):
+            mod.predict(
+                speed_ms=10.0,
+                distance_to_route_m=20.0,
+                heading_delta_deg=30.0,
+                route_progress_pct=40.0,
+                hour_of_day=10,
+            )
+
+        call_args = mock_model.predict.call_args[0][0]
+        assert call_args.shape == (1, 5)
+
+
+# ---------------------------------------------------------------------------
+# lru_cache — joblib.load called at most once per process lifetime
+# ---------------------------------------------------------------------------
+
+class TestLruCache:
+    def test_load_model_cached_after_first_call(self, tmp_path):
+        """_load_model() should call joblib.load exactly once, even when called twice."""
+        mod = _reload_module()  # fresh module with clear lru_cache
+        artifact = tmp_path / "isolation_forest.joblib"
+        artifact.write_bytes(b"placeholder")  # file must exist for os.path.exists check
+
+        mock_sklearn_model = MagicMock()
+
+        # Patch _artifact_path to return our tmp file, and joblib.load to avoid
+        # actually deserialising the placeholder bytes.
+        with patch.object(mod, "_artifact_path", return_value=str(artifact)), \
+             patch.object(mod, "joblib") as mock_joblib_mod:
+            mock_joblib_mod.load.return_value = mock_sklearn_model
+            first  = mod._load_model()
+            second = mod._load_model()
+
+        assert first is second
+        mock_joblib_mod.load.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# build_feature_vector — bounds and order
+# ---------------------------------------------------------------------------
+
+class TestBuildFeatureVector:
+    def test_returns_five_elements(self):
+        mod = _reload_module()
+        fv = mod.build_feature_vector(
+            speed_ms=5.0,
+            distance_to_route_m=20.0,
+            heading_delta_deg=45.0,
+            route_progress_pct=60.0,
+            hour_of_day=9,
+        )
+        assert len(fv) == 5
+
+    def test_heading_clamped_to_180(self):
+        mod = _reload_module()
+        fv = mod.build_feature_vector(0.0, 0.0, 270.0, 0.0, 0)
+        # 270 → clamped at 180
+        assert fv[2] == 180.0
+
+    def test_hour_clamped_to_23(self):
+        mod = _reload_module()
+        fv = mod.build_feature_vector(0.0, 0.0, 0.0, 0.0, 99)
+        assert fv[4] == 23.0
+
+    def test_route_progress_clamped_to_100(self):
+        mod = _reload_module()
+        fv = mod.build_feature_vector(0.0, 0.0, 0.0, 150.0, 0)
+        assert fv[3] == 100.0

--- a/services/websocket-service/main.py
+++ b/services/websocket-service/main.py
@@ -47,6 +47,17 @@ async def redis_listener(app: FastAPI):
                     if message and message["type"] == "message":
                         logger.info(f"GOT DATA FROM REDIS: {message}")
                         data = json.loads(message["data"])
+
+                        # Normalise eta:live messages for frontend consumption.
+                        # consumer.py emits eta_seconds (float, seconds).
+                        # Frontend socketService reads raw.eta (number, minutes).
+                        # Inject `eta` = rounded minutes so the frontend never
+                        # receives undefined and defaults to 0.
+                        if message["channel"] == settings.eta_channel:
+                            eta_s = data.get("eta_seconds")
+                            if eta_s is not None:
+                                data["eta"] = round(float(eta_s) / 60, 1)
+
                         await manager.broadcast(data)
                     await asyncio.sleep(0.1)
         except Exception as e:


### PR DESCRIPTION
## Summary

### 1. Fix: ETA always showing 0 min
- **Root cause**: `consumer.py` emits `eta_seconds` but frontend reads `eta` (minutes).
- **Fix** (`fix(websocket)`): websocket-service now injects `data["eta"] = round(eta_seconds / 60, 1)` before broadcasting, so `raw.eta` is populated for both frontend apps.

### 2. feat: SARIMA time-series ETA forecasting
- `eta-service`: SARIMA model for per-stop arrival time forecasting
- ETA persisted to `eta_db` PostgreSQL table
- Off-route guard: suppresses ETA updates when bus deviates from route

### 3. feat: IsolationForest unsupervised anomaly detection
- **`app/models/isolation_forest_model.py`**: production IF inference with `lru_cache` artifact loading
- **`models/training/train_isolation_forest.py`**: offline CLI trainer (InfluxDB → feature engineering → fit → joblib dump)
- **`app/models/anomaly_model.py`**: IF integrated before rule-based checks; falls back to rules if no artifact
- **`app/config.py`**: `ANOMALY_ISOLATION_FOREST_ARTIFACT_PATH` env var
- **`docker-compose.yml`**: env var wired into anomaly-service container
- **`requirements.txt`**: `scikit-learn>=1.3`, `joblib>=1.3`
- **`Dockerfile`**: creates artifact dir, sets `ENV ANOMALY_ISOLATION_FOREST_ARTIFACT_PATH`
- **10 unit tests** passing (TestMissingArtifact, TestValidArtifact, TestLruCache, TestBuildFeatureVector)

### 4. docs: Frontend socket fix instructions
- `docs/FRONTEND_SOCKET_ETA_FIX.md`: exact patch for `ontime-passenger-web` and `ontime-admin-web` to handle `eta_update` as merge-update (prevents bus markers jumping to 0,0)

## Commits
- `fix(websocket)`: normalise eta:live — inject eta(min) field for frontend
- `feat(anomaly)`: add isolation_forest_model.py — IF scorer with lru_cache artifact loading
- `feat(anomaly)`: add train_isolation_forest.py — unsupervised IF training CLI
- `feat(anomaly)`: integrate IsolationForest into detection pipeline with rule fallback
- `feat(anomaly)`: add scikit-learn + joblib deps and create IF artifact dir in Dockerfile
- `feat(anomaly)`: add ANOMALY_IF_ARTIFACT_PATH to config + docker-compose
- `test(anomaly)`: unit tests for isolation_forest_model — 10 passing
- `fix(anomaly)`: align Dockerfile + main.py with isolation_forest_artifact_path config field

## Test Plan
- [ ] `pytest services/anomaly-service/tests/unit/test_isolation_forest_model.py` — 10 tests pass
- [ ] GPS simulator running → websocket broadcasts `eta` field in minutes
- [ ] No bus markers jump to (0,0) on eta_update (frontend PR pending)