### PR TITLE
Add eta-service to build and publish workflow

### DIFF
--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -41,6 +41,9 @@ jobs:
           - service: anomaly-service
             context: services/anomaly-service
             dockerfile: services/anomaly-service/Dockerfile
+          - service: eta-service
+            context: .
+            dockerfile: services/eta-service/Dockerfile
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Adds `eta-service` to the build matrix in `image_publish.yml` so it gets built and pushed to GHCR on every push to `main`
- Uses the same root context (`.`) and `services/eta-service/Dockerfile` as the other root-context services
- Not added to the deploy step — will be wired up to the cluster separately

## Test plan
- [ ] Merge and verify the `eta-service` image appears in GHCR after the workflow runs