### PR TITLE
Add eta-service to workflow deploy step

### DIFF
--- a/.github/workflows/image_publish.yml
+++ b/.github/workflows/image_publish.yml
@@ -127,6 +127,9 @@ jobs:
           kubectl set image deployment/transit-platform-g2-anomaly-service \
             anomaly-service="ghcr.io/${repo}/anomaly-service:sha-${sha:0:7}" \
             -n transit-platform
+          kubectl set image deployment/transit-platform-g2-eta-service \
+            eta-service="ghcr.io/${repo}/eta-service:sha-${sha:0:7}" \
+            -n transit-platform
           kubectl rollout status deployment/transit-platform-g2-api-gateway \
             -n transit-platform --timeout=120s
           kubectl rollout status deployment/transit-platform-g2-ingestion \
@@ -134,6 +137,8 @@ jobs:
           kubectl rollout status deployment/transit-platform-g2-stream-processing \
             -n transit-platform --timeout=120s
           kubectl rollout status deployment/transit-platform-g2-anomaly-service \
+            -n transit-platform --timeout=120s
+          kubectl rollout status deployment/transit-platform-g2-eta-service \
             -n transit-platform --timeout=120s
 
       - name: Skip deploy (missing kubeconfig)


### PR DESCRIPTION
## Summary
- Adds `kubectl set image` and `kubectl rollout status` for `transit-platform-g2-eta-service` in the deploy step
- The deployment already exists in the cluster (applied manually with the k8s manifest)
- From now on, every push to `main` will automatically update the eta-service image to the new sha tag