### PR TITLE
Fix: enable Flink checkpointing so ETA features reach Kafka

### DIFF
--- a/services/stream-processing/app/job.py
+++ b/services/stream-processing/app/job.py
@@ -76,6 +76,7 @@ def run_telemetry_job():
     env = StreamExecutionEnvironment.get_execution_environment()
     env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
     env.set_parallelism(settings.flink_parallelism)
+    env.enable_checkpointing(10000)  # flush Kafka sinks every 10 s
 
     # 2. Define Kafka Source for raw telemetry
     telemetry_source = KafkaSource.builder() \


### PR DESCRIPTION
## Problem
The Flink `KafkaSink` with `AT_LEAST_ONCE` delivery buffers records internally and only flushes them during a checkpoint. Without `env.enable_checkpointing()`, no checkpoint is ever triggered, so `transport-eta-features` and `transport-telemetry-cleaned` Kafka topics received zero messages — even though the Redis sink (which writes directly via Python) was working fine.

## Fix
Added `env.enable_checkpointing(10000)` — triggers a checkpoint every 10 seconds, which flushes the buffered Kafka records.

## Effect
- `transport-eta-features` will now receive enriched GPS messages every ~10 s
- The ETA service (now deployed) will consume them and publish to `eta:live`
- Passengers will see live ETA in the app