### PR TITLE
Add logging to eta-service for consumer thread visibility

### DIFF
--- a/services/eta-service/main.py
+++ b/services/eta-service/main.py
@@ -12,7 +12,7 @@ from app.config import settings
 from consumer import EtaFeatureConsumer, render_prometheus_metrics
 from routers.eta import router as eta_router
 
-
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("eta-service")
 
 


### PR DESCRIPTION
Enable INFO level logging in eta-service FastAPI app to see consumer thread startup messages and troubleshoot why ETA predictions aren't being made.