### PR TITLE
Fix: consume ETA features from start of topic

### DIFF
--- a/services/eta-service/consumer.py
+++ b/services/eta-service/consumer.py
@@ -458,7 +458,7 @@ class EtaFeatureConsumer:
             self.topic_name,
             bootstrap_servers=self.kafka_broker_url,
             group_id=self.consumer_group_id,
-            auto_offset_reset="latest",
+            auto_offset_reset="earliest",
             enable_auto_commit=True,
             value_deserializer=lambda value: value.decode("utf-8"),
         )

--- a/services/eta-service/main.py
+++ b/services/eta-service/main.py
@@ -12,7 +12,7 @@ from app.config import settings
 from consumer import EtaFeatureConsumer, render_prometheus_metrics
 from routers.eta import router as eta_router
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
 logger = logging.getLogger("eta-service")
 
 


### PR DESCRIPTION
Change Kafka consumer auto_offset_reset from 'latest' to 'earliest' so eta-service processes all ETA feature messages from the transport-eta-features topic, not just new ones.